### PR TITLE
Make the tests pass even if the scripts are not executable

### DIFF
--- a/hamming/hamming_test.sh
+++ b/hamming/hamming_test.sh
@@ -1,104 +1,104 @@
 @test "Short identical strands have hamming distance of zero" {
-  run ./hamming.sh C C
+  run bash hamming.sh C C
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 0 ]
 }
 
 @test "Long identical strands have hamming distance of zero" {
-  run ./hamming.sh CATSCATS CATSCATS
+  run bash hamming.sh CATSCATS CATSCATS
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 0 ]
 }
 
 @test "Single char different strings have hamming distance of one" {
-  run ./hamming.sh C A
+  run bash hamming.sh C A
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 1 ]
 }
 
 @test "Distance with all chars different in small strings" {
-  run ./hamming.sh GC AT
+  run bash hamming.sh GC AT
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 2 ]
 }
 
 @test "small distance with small strands" {
-  run ./hamming.sh GC GT
+  run bash hamming.sh GC GT
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 1 ]
 }
 
 @test "small distance" {
-  run ./hamming.sh GGACG GGTCG
+  run bash hamming.sh GGACG GGTCG
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 1 ]
 }
 
 @test "small distance in long strands" {
-  run ./hamming.sh ACCAGGG ACTATGG
+  run bash hamming.sh ACCAGGG ACTATGG
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 2 ]
 }
 
 @test "non unique char in first strand" {
-  run ./hamming.sh AGA AGG
+  run bash hamming.sh AGA AGG
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 1 ]
 }
 
 @test "non unique char in second strand" {
-  run ./hamming.sh AGG AGA
+  run bash hamming.sh AGG AGA
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 1 ]
 }
 
 @test "large distance" {
-  run ./hamming.sh GATACA GCATAA
+  run bash hamming.sh GATACA GCATAA
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 4 ]
 }
 
 @test "large distance in off by one strand" {
-  run ./hamming.sh GGACGGATTCTG AGGACGGATTCT
+  run bash hamming.sh GGACGGATTCTG AGGACGGATTCT
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 9 ]
 }
 
 @test "empty strands" {
-  run ./hamming.sh "" ""
+  run bash hamming.sh "" ""
 
   [ "$status" -eq 0 ]
   [ "$output" -eq 0 ]
 }
 
 @test "first string longer" {
-  run ./hamming.sh AGT AG
+  run bash hamming.sh AGT AG
 
   [ "$status" -eq 1 ]
   [ "$output" = "The two strands must have the same length." ]
 }
 
 @test "second string longer" {
-  run ./hamming.sh AGT AGTC
+  run bash hamming.sh AGT AGTC
 
   [ "$status" -eq 1 ]
   [ "$output" = "The two strands must have the same length." ]
 }
 
 @test "no input" {
-  run ./hamming.sh
+  run bash hamming.sh
 
   [ "$status" -eq 1 ]
-  [ "$output" = "Usage: ./hamming.sh <string1> <string2>" ]
+  [ "$output" = "Usage: hamming.sh <string1> <string2>" ]
 }

--- a/hello-world/hello_world_test.sh
+++ b/hello-world/hello_world_test.sh
@@ -1,35 +1,34 @@
 @test "When given no name, it should greet the world!" {
-  run ./hello_world.sh
+  run bash hello_world.sh
 
   [ "$status" -eq 0 ]
   [ "$output" = "Hello, World!" ]
 }
 
 @test 'When given "Alice" it should greet Alice!' {
-  run ./hello_world.sh Alice
+  run bash hello_world.sh Alice
 
   [ "$status" -eq 0 ]
   [ "$output" = "Hello, Alice!" ]
 }
 
 @test 'When given "Bob" it should greet Bob!' {
-  run ./hello_world.sh Bob
+  run bash hello_world.sh Bob
 
   [ "$status" -eq 0 ]
   [ "$output" = "Hello, Bob!" ]
 }
 
 @test 'When given an empty string it should have a space and punctuation, though admittedly this is strange.' {
-  run ./hello_world.sh ""
+  run bash hello_world.sh ""
 
   [ "$status" -eq 0 ]
   [ "$output" = "Hello, !" ]
 }
 
 @test 'When given "Alice and Bob" it greets them both' {
-  run ./hello_world.sh Alice and Bob
+  run bash hello_world.sh Alice and Bob
 
   [ "$status" -eq 0 ]
   [ "$output" = "Hello, Alice and Bob!" ]
 }
-


### PR DESCRIPTION
Execute the scripts to test with bash
(ex: 'bash script_name.sh')
instead of executing the scripts directly (ex: './script_name.sh'), which requires the files to be executable.

Else a user might be confused as to why the scripts don't pass the test.

I'm not 100% sure this is desirable behavior (it makes a shebang `#!/bin/bash` useless in the scripts), so please review.

Another approach might be to add more information in the readme file, like:

"Make sure the script is executable with `chmod +x script_name.sh`"
