### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# xBash
+# Exercism Bash Track
 
-[![Gitter](https://badges.gitter.im/exercism/xbash.svg)](https://gitter.im/exercism/xbash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Gitter](https://badges.gitter.im/exercism/bash.svg)](https://gitter.im/exercism/bash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism Exercises in Bash
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "bash",
   "language": "Bash",
-  "repository": "https://github.com/exercism/xbash",
+  "repository": "https://github.com/exercism/bash",
   "checklist_issue": 4,
   "active": false,
   "exercises": [


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1