### PR TITLE
Support a subcommand on configlet in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: bash
 sudo: false
 script:
 - bin/fetch-configlet
-- bin/configlet .
+- bin/configlet lint .


### PR DESCRIPTION
We will be adding subcommands to configlet.

For now, we've released a version of configlet which handles both the
old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we release the version of configlet that requires the subcommand.

See https://github.com/exercism/configlet/pull/23