### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,78 +6,115 @@
   "active": false,
   "exercises": [
     {
+      "uuid": "4e2533dd-3af5-400b-869d-78140764d533",
       "slug": "hello-world",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "176c1a86-28b1-4848-9f87-bd6ae10db6ba",
       "slug": "gigasecond",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "e24451fd-761d-4d20-81d9-e470486ec44a",
       "slug": "leap",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "68103f44-b442-48e6-b2b5-09001f73e926",
       "slug": "hamming",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8a62e53e-59c2-42d5-96e5-a0f8f9b5d177",
       "slug": "rna-transcription",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "1a9c8d65-43ee-435e-8c55-9a45c14a71fb",
       "slug": "raindrops",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9ac0b041-a7aa-4b0c-952a-d38d35e2cd65",
       "slug": "bob",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ca5139b4-8b2f-44ea-8d83-0b8ca7674436",
       "slug": "difference-of-squares",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "33d9eb48-5958-4e98-afc0-8cff89577c86",
       "slug": "anagram",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a7e2018a-c454-4fe0-ad35-229304306648",
       "slug": "pangram",
+      "active": true,
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     }
-  ],
-  "deprecated": [
-
   ],
   "foregone": [
 


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the
[progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md)
design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises
appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming
that this is a core exercise, but there is no reason that it needs to be.

active: false is the equivalent of _deprecated_, which was stored in a separate array. This array
is being removed in this change.

With these defaults the track in nextercism will have no core exercises, and all the exercises
will be available as 'extras' from the start.


See https://github.com/exercism/discussions/issues/159 for the discussion about the new configuration.