### PR TITLE
config.json: Fix uuid key for error-handling exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -149,7 +149,7 @@
         "error_handling",
         "input_validation"
       ],
-      "uudi": "b2b4ee35-108f-45ce-b294-c10d332e5579"
+      "uuid": "b2b4ee35-108f-45ce-b294-c10d332e5579"
     }
   ],
   "foregone": [],


### PR DESCRIPTION
When validating UUIDs for all tracks I found that the exercise `error-handling` had a small typo for the uuid key. 