### PR TITLE
fix link to new contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Exercises in Bash
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
+Please see the [contributing guide](https://github.com/exercism/bash/blob/master/CONTRIBUTING.md)
 
 
 ### Bash icon

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Exercism Exercises in Bash
 
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/bash/blob/master/CONTRIBUTING.md)
+Please see the [contributing guide](https://github.com/exercism/bash/blob/master/CONTRIBUTING.md) for information.
 
 
 ### Bash icon


### PR DESCRIPTION
Points users to the new contributing document provided in #96 as opposed to the generic `xapi` contributing document.