### PR TITLE
fix contributing highlighting 'invalid' json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Once your tests and example are complete, rename `<your-exercise>.sh` to `exampl
 
 Exercism makes heavy use of configuration files to automate things.  Now that you're done with your solution, you can add your problem to `bash/config.json`.  Check out the [configuration description](https://github.com/exercism/docs/blob/master/language-tracks/configuration/exercises.md) in the Exercism docs for more info on each item.
 
-```
+```javascript
 // config.json
 {
   "exercises": [

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Once your tests and example are complete, rename `<your-exercise>.sh` to `exampl
 
 Exercism makes heavy use of configuration files to automate things.  Now that you're done with your solution, you can add your problem to `bash/config.json`.  Check out the [configuration description](https://github.com/exercism/docs/blob/master/language-tracks/configuration/exercises.md) in the Exercism docs for more info on each item.
 
-```json
+```
 // config.json
 {
   "exercises": [


### PR DESCRIPTION
I've removed the `json` identifier from the json code block in `CONTRIBUTING.md`, as it was being highlighted in red (invalid) as json does not support comments.

Personally, I think this is slightly ugly looking, and as it isn't *really* json, I think it is an improvement to remove the red highlighting.

Let me know what the rest of you think and if this is seen as an improvement we can merge it :slightly_smiling_face: 