### PR TITLE
add MAINTAINING.md doc

### DIFF
--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,0 +1,36 @@
+# Welcome!
+
+This is a guide/reference for maintainers of the Bash track.
+
+- [Your Permissions](#your-permissions)
+- [Maintainer Guides](#maintainer-guides)
+- [Miscellaneous](#miscellaneous)
+
+## Your Permissions 
+
+As a maintainer, you have write access to several repositories.  "write access" means you can: review, reject, accept and merge PRs; and push changes to these repos.  Despite having permissions to push directly, we tend to seek review of even our own PRs.
+
+### Track-specific
+
+- [bash](https://github.com/exercism/bash) — Probably where you are now!
+
+### Exercism-wide
+
+- [problem-specifications](https://github.com/exercism/problem-specifications) — the library of canonical exercises.
+- [discussions](https://github.com/exercism/discussions) — the place where project-wide conversations happen. 
+  [issues sorted by most recently updated.](https://github.com/exercism/discussions/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
+- [docs](https://github.com/exercism/docs) - the place to find project-wide documentation.
+
+## Maintainer Guides
+
+- **[docs/maintaining-a-track/README.md](https://github.com/exercism/docs/blob/master/maintaining-a-track/README.md)**
+- [docs/contributing-to-language-tracks/README.md](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks/README.md)
+- [docs/you-can-help/review-pull-requests.md](https://github.com/exercism/docs/blob/master/you-can-help/review-pull-requests.md)
+
+## Miscellaneous
+
+- Issues marked with "policy" are current "team agreements": [exercism?label:policy](https://github.com/search?q=org%3Aexercism+label%3Apolicy).
+  This label is described in [discussions#96](https://github.com/exercism/discussions/issues/96).
+- Exercism has a Twitter account: [@Exercism.io](https://twitter.com/exercism_io); and a mailing list: https://tinyletter.com/exercism
+
+**Please feel free to ask any questions.  In our thinking, asking questions is far smarter than guessing.**


### PR DESCRIPTION
Add markdown to describe the duties of maintaining a repo.

This is heavily influenced by the Java track's document, as I think it is a great example.