### PR TITLE
error-handling: add readme

### DIFF
--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -8,7 +8,7 @@ This exercise requires you to handle various errors. Because error handling is r
 
 Run the tests with:
 
-    bats whatever_test.sh
+    bats error_handling_test.sh
 
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -1,0 +1,15 @@
+# Error-handling
+
+Implement various kinds of error handling and resource management.
+
+An important point of programming is how to handle errors and close resources even if errors occur.
+
+This exercise requires you to handle various errors. Because error handling is rather programming language specific you'll have to refer to the tests for your track to see what's exactly required.
+
+Run the tests with:
+
+    bats whatever_test.sh
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.
+


### PR DESCRIPTION
Looks like `error-handling` didn't have a README, so I've generated one.

As the [`metadata.yml`](https://github.com/exercism/problem-specifications/blob/master/exercises/error-handling/metadata.yml) doesn't have a source, I've omitted that section.