### PR TITLE
_template: add a template for quickly porting exercises to track

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,9 @@ In order to run any of the test files (or examples, for that matter), you're goi
 
 ## Porting an Exercise from Another Language
 
-Porting an exercise from another language is easy (ish)!  You can follow this step-by-step guide (specific for this repository) to get it done.
+Porting an exercise from another language is easy (ish)! [Problem specifications](www.github.com/exercism/problem-specifications) for [unimplemented exercises](www.exercism.io/languages/bash/todo) can be used to do this.
+
+The `_template` directory found in `exercism/bash` can be used to port exercises. Once an example submission, full test suite and README.md have been created, you just need to alter `config.json` to include the newly implemented exercise.
 
 ### Initial Setup
 

--- a/_template/README.md
+++ b/_template/README.md
@@ -1,0 +1,11 @@
+# README 
+
+All exercises should have a README.md file. This file should be generated using the `configlet` tool.
+
+If a `hints.md` file has been added to an exericse, that exercise's `readme` needs to be regenerated. This is because the `hints.md` file will get appended to the `readme` when the `readme` is generated.
+
+To generate the `readme` you need to:
+
+1. Download [`configlet`](https://github.com/exercism/configlet/releases) and put it somewhere on your path (`configlet` is the tool we use to generate `reame` files).
+2. [Clone](https://help.github.com/articles/cloning-a-repository/) the [problem-specifications](https://github.com/exercism/problem-specifications) repository (this repo contains the template we use to generate `readme`s).
+3. Run `configlet generate . --only exercise-slug --spec-path path_to_problem_specifications` from the root of this repository (exercism/bash).

--- a/_template/example.sh
+++ b/_template/example.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A solution to the exercise, passing all tests, should be here

--- a/_template/example.sh
+++ b/_template/example.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+# A solution to the exercise, passing all tests, should be here

--- a/_template/exercise_slug_test.sh
+++ b/_template/exercise_slug_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+@test "Test name - first test shouldn't be skipped" {
+  #skip
+  run bash exercise_slug.sh
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "What's expected" ]
+}
+
+@test "Second test onwards should be skipped" {
+  skip
+  run bash exercise_slug.sh
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "What's expected" ]
+}


### PR DESCRIPTION
Adds a `_template` directory with a basic exercise outline, to facilitate more uniform contributions.