### PR TITLE
config.json: review exercise difficulty/unlocks/ordering

### DIFF
--- a/config.json
+++ b/config.json
@@ -34,7 +34,7 @@
       "uuid": "2b6d4faa-1909-422a-8eac-1682be3f1b9e"
     },
     {
-      "core": true,
+      "core": false,
       "difficulty": 1,
       "slug": "two-fer",
       "topics": [
@@ -43,6 +43,7 @@
         "strings",
         "text_formatting"
       ],
+      "unlocked_by": "null",
       "uuid": "0cfac255-6871-4588-a16b-98f7692bfdbe"
     },
     {
@@ -68,7 +69,7 @@
       "uuid": "ca5139b4-8b2f-44ea-8d83-0b8ca7674436"
     },
     {
-      "core": true,
+      "core": false,
       "difficulty": 2,
       "slug": "error-handling",
       "topics": [
@@ -77,18 +78,8 @@
         "stdout",
         "strings"
       ],
+      "unlocked_by": "null",
       "uuid": "b2b4ee35-108f-45ce-b294-c10d332e5579"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "gigasecond",
-      "topics": [
-        "dates",
-        "mathematics"
-      ],
-      "unlocked_by": "armstrong-numbers",
-      "uuid": "176c1a86-28b1-4848-9f87-bd6ae10db6ba"
     },
     {
       "core": true,
@@ -101,7 +92,7 @@
       "uuid": "68103f44-b442-48e6-b2b5-09001f73e926"
     },
     {
-      "core": true,
+      "core": false,
       "difficulty": 2,
       "slug": "leap",
       "topics": [
@@ -109,6 +100,7 @@
         "control_flow_conditionals",
         "input_validation"
       ],
+      "unlocked_by": "null",
       "uuid": "e24451fd-761d-4d20-81d9-e470486ec44a"
     },
     {
@@ -142,7 +134,7 @@
         "control_flow_loops",
         "error_handling"
       ],
-      "unlocked_by": "error-handling",
+      "unlocked_by": "pangram",
       "uuid": "8a62e53e-59c2-42d5-96e5-a0f8f9b5d177"
     },
     {
@@ -180,7 +172,7 @@
         "strings",
         "stdout"
       ],
-      "unlocked_by": "two-fer",
+      "unlocked_by": "hello-world",
       "uuid": "9ac0b041-a7aa-4b0c-952a-d38d35e2cd65"
     },
     {
@@ -205,7 +197,7 @@
         "error_handling",
         "string_comparison"
       ],
-      "unlocked-by": "error-handling",
+      "unlocked-by": "pangram",
       "uuid": "28f848c8-56ef-4147-a401-f1617c147b4b"
     },
     {
@@ -232,7 +224,7 @@
         "number_comparison",
         "mathematics"
       ],
-      "unlocked_by": "leap",
+      "unlocked_by": "armstrong-numbers",
       "uuid": "0f79f9ab-4a51-468c-88ca-84f0bf7cfc38"
     },
     {
@@ -246,6 +238,17 @@
       ],
       "unlocked_by": "pangram",
       "uuid": "51bd6542-408b-4a73-8343-1c4d50db5315"
+    },
+    {
+      "core": false,
+      "difficulty": 4,
+      "slug": "gigasecond",
+      "topics": [
+        "dates",
+        "mathematics"
+      ],
+      "unlocked_by": "armstrong-numbers",
+      "uuid": "176c1a86-28b1-4848-9f87-bd6ae10db6ba"
     },
     {
       "core": true,

--- a/config.json
+++ b/config.json
@@ -5,9 +5,21 @@
     {
       "core": true,
       "difficulty": 1,
+      "slug": "grains",
+      "topics": [
+        "control_flow_conditionals",
+        "input_validation",
+        "mathematics"
+      ],
+      "uuid": "c9d36155-10e8-4a75-a732-3c43a68910eb"
+    },
+    {
+      "core": true,
+      "difficulty": 1,
       "slug": "hello-world",
       "topics": [
-        "stdout"
+        "stdout",
+        "strings"
       ],
       "uuid": "4e2533dd-3af5-400b-869d-78140764d533"
     },
@@ -16,33 +28,81 @@
       "difficulty": 1,
       "slug": "reverse-string",
       "topics": [
+        "stdout",
         "strings"
       ],
       "uuid": "2b6d4faa-1909-422a-8eac-1682be3f1b9e"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 1,
-      "slug": "gigasecond",
+      "slug": "two-fer",
       "topics": [
-        "dates"
+        "control_flow_conditionals",
+        "stdout",
+        "strings",
+        "text_formatting"
       ],
-      "unlocked_by": null,
-      "uuid": "176c1a86-28b1-4848-9f87-bd6ae10db6ba"
-    },
-    {
-      "core": false,
-      "difficulty": 1,
-      "slug": "bob",
-      "topics": [
-        "control_flow_conditionals"
-      ],
-      "unlocked_by": null,
-      "uuid": "9ac0b041-a7aa-4b0c-952a-d38d35e2cd65"
+      "uuid": "0cfac255-6871-4588-a16b-98f7692bfdbe"
     },
     {
       "core": true,
-      "difficulty": 1,
+      "difficulty": 2,
+      "slug": "armstrong-numbers",
+      "topics": [
+        "integers",
+        "mathematics"
+      ],
+      "uuid": "302b7e1a-4cf6-47d4-8048-b675f667fc98"
+    },
+    {
+      "core": false,
+      "difficulty": 2,
+      "slug": "difference-of-squares",
+      "topics": [
+        "control_flow_conditionals",
+        "control_flow_loops",
+        "mathematics"
+      ],
+      "unlocked_by": "armstrong-numbers",
+      "uuid": "ca5139b4-8b2f-44ea-8d83-0b8ca7674436"
+    },
+    {
+      "core": true,
+      "difficulty": 2,
+      "slug": "error-handling",
+      "topics": [
+        "error_handling",
+        "input_validation",
+        "stdout",
+        "strings"
+      ],
+      "uuid": "b2b4ee35-108f-45ce-b294-c10d332e5579"
+    },
+    {
+      "core": false,
+      "difficulty": 2,
+      "slug": "gigasecond",
+      "topics": [
+        "dates",
+        "mathematics"
+      ],
+      "unlocked_by": "armstrong-numbers",
+      "uuid": "176c1a86-28b1-4848-9f87-bd6ae10db6ba"
+    },
+    {
+      "core": true,
+      "difficulty": 2,
+      "slug": "hamming",
+      "topics": [
+        "control_flow_loops",
+        "string_comparison"
+      ],
+      "uuid": "68103f44-b442-48e6-b2b5-09001f73e926"
+    },
+    {
+      "core": true,
+      "difficulty": 2,
       "slug": "leap",
       "topics": [
         "boolean_logic",
@@ -53,101 +113,25 @@
     },
     {
       "core": true,
-      "difficulty": 1,
-      "slug": "grains",
-      "topics": [
-        "control_flow_conditionals",
-        "input_validation",
-        "mathematics"
-      ],
-      "uuid": "c9d36155-10e8-4a75-a732-3c43a68910eb"
-    },
-    {
-      "core": false,
-      "difficulty": 1,
-      "slug": "acronym",
-      "topics": [
-        "string_transformation",
-        "input_validation"
-      ],
-      "unlocked_by": null,
-      "uuid": "5812c10a-aee1-11e7-add7-ef139384f6eb"
-    },
- {
-      "core": false,
-      "difficulty": 1,
-      "slug": "raindrops",
-      "topics": [
-        "control_flow_conditionals",
-        "input_validation"
-      ],
-      "unlocked_by": "leap",
-      "uuid": "1a9c8d65-43ee-435e-8c55-9a45c14a71fb"
-    },
-    {
-      "core": false,
-      "difficulty": 1,
-      "slug": "difference-of-squares",
-      "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "string_comparison",
-        "string_transformation"
-      ],
-      "unlocked_by": "leap",
-      "uuid": "ca5139b4-8b2f-44ea-8d83-0b8ca7674436"
-    },
-    {
-      "core": true,
-      "difficulty": 1,
-      "slug": "error-handling",
-      "topics": [
-        "error_handling",
-        "input_validation"
-      ],
-      "uuid": "b2b4ee35-108f-45ce-b294-c10d332e5579"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "armstrong-numbers",
-      "topics": [
-        "integers",
-        "mathematics"
-      ],
-      "unlocked_by": null,
-      "uuid": "302b7e1a-4cf6-47d4-8048-b675f667fc98"
-    },
-    {
-      "core": true,
       "difficulty": 2,
       "slug": "pangram",
       "topics": [
-        "string_transformation"
+        "string_transformation",
+        "strings"
       ],
       "uuid": "a7e2018a-c454-4fe0-ad35-229304306648"
     },
     {
       "core": false,
       "difficulty": 2,
-      "slug": "anagram",
+      "slug": "raindrops",
       "topics": [
-        "control_flow_loops",
-        "string_transformation"
+        "control_flow_conditionals",
+        "input_validation",
+        "strings"
       ],
-      "unlocked_by": "pangram",
-      "uuid": "33d9eb48-5958-4e98-afc0-8cff89577c86"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "hamming",
-      "topics": [
-        "control_flow_loops",
-        "string_comparison"
-      ],
-      "unlocked_by": "pangram",
-      "uuid": "68103f44-b442-48e6-b2b5-09001f73e926"
+      "unlocked_by": "reverse-string",
+      "uuid": "1a9c8d65-43ee-435e-8c55-9a45c14a71fb"
     },
     {
       "core": false,
@@ -155,80 +139,49 @@
       "slug": "rna-transcription",
       "topics": [
         "associative_arrays",
-        "control_flow_loops"
+        "control_flow_loops",
+        "error_handling"
       ],
-      "unlocked_by": "pangram",
+      "unlocked_by": "error-handling",
       "uuid": "8a62e53e-59c2-42d5-96e5-a0f8f9b5d177"
     },
     {
       "core": false,
-      "difficulty": 2,
-      "slug": "two-fer",
+      "difficulty": 3,
+      "slug": "acronym",
       "topics": [
-        "control_flow_conditionals",
-        "text_formatting"
-      ],
-      "unlocked_by": "pangram",
-      "uuid": "0cfac255-6871-4588-a16b-98f7692bfdbe"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "nucleotide-count",
-      "topics": [
-        "control_flow_loops",
-        "string_comparison"
-      ],
-      "unlocked-by": "panagram",
-      "uuid": "28f848c8-56ef-4147-a401-f1617c147b4b"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "word-count",
-      "topics": [
-        "control_flow_loops",
-        "string_comparison"
-      ],
-      "unlocked_by": "pangram",
-      "uuid": "51bd6542-408b-4a73-8343-1c4d50db5315"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "triangle",
-      "topics": [
-        "boolean_logic",
         "input_validation",
-        "number_comparison",
-        "mathematics"
-      ],
-      "unlocked_by": "leap",
-      "uuid": "0f79f9ab-4a51-468c-88ca-84f0bf7cfc38"
-    },
-    {
-      "core": false,
-      "difficulty": 2,
-      "slug": "phone-number",
-      "topics": [
-        "control_flow_conditionals",
-        "string_comparison"
+        "string_transformation"
+        "strings"
       ],
       "unlocked_by": "pangram",
-      "uuid": "9f9a1a49-472f-4a39-aa28-6aa17eeebdc7"
+      "uuid": "5812c10a-aee1-11e7-add7-ef139384f6eb"
     },
     {
       "core": false,
       "difficulty": 3,
-      "slug": "luhn",
+      "slug": "anagram",
       "topics": [
-        "algorithms",
         "control_flow_conditionals",
-        "integers",
-        "mathematics"
+        "control_flow_loops",
+        "stdout",
+        "strings",
+        "string_transformation"
       ],
-      "unlocked_by": "difference-of-squares",
-      "uuid": "a3b16d02-2963-445d-9339-7e3002375a71"
+      "unlocked_by": "pangram",
+      "uuid": "33d9eb48-5958-4e98-afc0-8cff89577c86"
+    },
+    {
+      "core": false,
+      "difficulty": 3,
+      "slug": "bob",
+      "topics": [
+        "control_flow_conditionals",
+        "strings",
+        "stdout"
+      ],
+      "unlocked_by": "two-fer",
+      "uuid": "9ac0b041-a7aa-4b0c-952a-d38d35e2cd65"
     },
     {
       "core": false,
@@ -240,8 +193,71 @@
         "integers",
         "mathematics"
       ],
-      "unlocked_by": "armstrong-numbers",
+      "unlocked_by": "grains",
       "uuid": "b4793e6d-f443-41ea-8289-95e18a5dbef4"
+    },
+    {
+      "core": false,
+      "difficulty": 3,
+      "slug": "nucleotide-count",
+      "topics": [
+        "control_flow_loops",
+        "error_handling"
+        "string_comparison"
+      ],
+      "unlocked-by": "error-handling",
+      "uuid": "28f848c8-56ef-4147-a401-f1617c147b4b"
+    },
+    {
+      "core": false,
+      "difficulty": 3,
+      "slug": "phone-number",
+      "topics": [
+        "control_flow_conditionals",
+        "error_handling",
+        "string_comparison",
+        "string_transformation"
+      ],
+      "unlocked_by": "pangram",
+      "uuid": "9f9a1a49-472f-4a39-aa28-6aa17eeebdc7"
+    },
+    {
+      "core": false,
+      "difficulty": 3,
+      "slug": "triangle",
+      "topics": [
+        "boolean_logic",
+        "error_handling",
+        "input_validation",
+        "number_comparison",
+        "mathematics"
+      ],
+      "unlocked_by": "leap",
+      "uuid": "0f79f9ab-4a51-468c-88ca-84f0bf7cfc38"
+    },
+    {
+      "core": false,
+      "difficulty": 3,
+      "slug": "word-count",
+      "topics": [
+        "control_flow_loops",
+        "string_comparison",
+        "strings"
+      ],
+      "unlocked_by": "pangram",
+      "uuid": "51bd6542-408b-4a73-8343-1c4d50db5315"
+    },
+    {
+      "core": true,
+      "difficulty": 4,
+      "slug": "luhn",
+      "topics": [
+        "algorithms",
+        "control_flow_conditionals",
+        "integers",
+        "mathematics"
+      ],
+      "uuid": "a3b16d02-2963-445d-9339-7e3002375a71"
     },
     {
       "core": false,
@@ -266,7 +282,7 @@
         "mathematics",
         "strings"
       ],
-      "unlocked_by": "hamming",
+      "unlocked_by": "luhn",
       "uuid": "7cc44e62-d29e-41c3-b4dd-689229e3e25a"
     }
  ],

--- a/config.json
+++ b/config.json
@@ -151,7 +151,7 @@
       "slug": "acronym",
       "topics": [
         "input_validation",
-        "string_transformation"
+        "string_transformation",
         "strings"
       ],
       "unlocked_by": "pangram",
@@ -202,7 +202,7 @@
       "slug": "nucleotide-count",
       "topics": [
         "control_flow_loops",
-        "error_handling"
+        "error_handling",
         "string_comparison"
       ],
       "unlocked-by": "error-handling",

--- a/config.json
+++ b/config.json
@@ -24,13 +24,14 @@
       "uuid": "4e2533dd-3af5-400b-869d-78140764d533"
     },
     {
-      "core": true,
+      "core": false,
       "difficulty": 1,
       "slug": "reverse-string",
       "topics": [
         "stdout",
         "strings"
       ],
+      "unlocked_by": "hello-world",
       "uuid": "2b6d4faa-1909-422a-8eac-1682be3f1b9e"
     },
     {
@@ -122,7 +123,7 @@
         "input_validation",
         "strings"
       ],
-      "unlocked_by": "reverse-string",
+      "unlocked_by": "hello-world",
       "uuid": "1a9c8d65-43ee-435e-8c55-9a45c14a71fb"
     },
     {
@@ -164,7 +165,7 @@
       "uuid": "33d9eb48-5958-4e98-afc0-8cff89577c86"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 3,
       "slug": "bob",
       "topics": [
@@ -172,7 +173,6 @@
         "strings",
         "stdout"
       ],
-      "unlocked_by": "hello-world",
       "uuid": "9ac0b041-a7aa-4b0c-952a-d38d35e2cd65"
     },
     {
@@ -263,7 +263,7 @@
       "uuid": "a3b16d02-2963-445d-9339-7e3002375a71"
     },
     {
-      "core": false,
+      "core": true,
       "difficulty": 5,
       "slug": "atbash-cipher",
       "topics": [
@@ -271,7 +271,6 @@
         "pattern_matching",
         "strings"
       ],
-      "unlocked_by": "hamming",
       "uuid": "5bff4fe1-6330-4730-b586-dcc5438c02ee"
     },
     {


### PR DESCRIPTION
Massive `config.json` overhaul!

Quick review:
* exercises are listed in difficulty order, and then by alphabetical order
* reviewed difficulty - most exercises were 1 or 2, but this isn't reflective (in my opinion) of the exercises
* add/remove topics as appropriate (and per many open issues) and alphabetise them accordingly
* added a couple more core exercises (luhn, two-fer etc.) to more evenly distribute exercise unlock
  
Fixes #61, #62, #63, #64, #65, #66, #67, #68, #69, #70, #71, #72, #73, #74, #75, #103, and #109
  