### PR TITLE
readme: add travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Exercism Bash Track
 
+[![Build Status](https://travis-ci.org/exercism/bash.svg?branch=master)](https://travis-ci.org/exercism/bash)
 [![Gitter](https://badges.gitter.im/exercism/bash.svg)](https://gitter.im/exercism/bash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism Exercises in Bash


### PR DESCRIPTION
I thought it would be a good idea to add the Travis build badge in order to show visitors the state of our master branch at present.

Looks like most other tracks do the same thing.