### PR TITLE
[error-handling] Fix tests to be CI friendly

### DIFF
--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -1,36 +1,32 @@
 #!/usr/bin/env bats
 
 @test "correct arguments" {
-    #skip
-    run bash error_handling.sh Alice
-    
-    [ "$status" -eq 0 ]
-    [ "$output" = "Hello, Alice" ]
+  #skip
+  run bash error_handling.sh Alice
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "Hello, Alice" ]
 }
 
 @test "one long argument" {
-    skip
-    run bash error_handling.sh "Alice and Bob"
-    
-    [ "$status" -eq 0 ]
-    [ "$output" = "Hello, Alice and Bob" ]
+  skip
+  run bash error_handling.sh "Alice and Bob"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "Hello, Alice and Bob" ]
 }
 
 @test "incorrect arguments" {
-    skip
-    run bash error_handling.sh Alice Bob
+  skip
+  run bash error_handling.sh Alice Bob
 
-    [ "$status" -ne 0 ]
+  [ "$status" -ne 0 ]
 }
 
-@test "use errexit" {
-    skip
-    source error_handling.sh
-    [ echo $SHELLOPTS | grep -q 'errexit' ]
-}
+@test "print usage banner with no value given" {
+  skip
+  run bash error_handling.sh
 
-@test "use nounset" {
-    skip
-    source error_handling.sh
-    [ echo $SHELLOPTS | grep -q 'nounset' ]
+  [ "$status" -eq 1 ]
+  [ "$output" = "Usage: ./error_handling <greetee>" ]
 }

--- a/exercises/error-handling/example.sh
+++ b/exercises/error-handling/example.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
-set -eu
+set -o errexit
+set -o nounset
 
-if test $# -gt 1
-then
-    echo "Usage: hello <greetee>"
-    exit 1
+if [ $# -ne 1 ]; then
+  echo "Usage: ./error_handling <greetee>"
+  exit 1
 else
-    echo "Hello, ${1}"
+  echo "Hello, ${1}"
+  exit 0
 fi


### PR DESCRIPTION
The current test "works" when you run it from the CLI in the sense that it does not error, but it does not correctly makes the test pass.

Changes:
- Apply style guide
- Do not check for -e and -u options, since they are suggestions (and mostly because there is not a proper way to test them with bats)
- Add test for output banner, since it's pretty much required for scripts, and IMO it's better than having the script fail with obscure message (unbound variable)