### PR TITLE
config.json: Fix unlocked_by errors being reported by Configlet

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,7 @@
         "strings",
         "text_formatting"
       ],
-      "unlocked_by": "null",
+      "unlocked_by": null,
       "uuid": "0cfac255-6871-4588-a16b-98f7692bfdbe"
     },
     {
@@ -91,7 +91,7 @@
         "stdout",
         "strings"
       ],
-      "unlocked_by": "null",
+      "unlocked_by": null,
       "uuid": "b2b4ee35-108f-45ce-b294-c10d332e5579"
     },
     {
@@ -113,7 +113,7 @@
         "control_flow_conditionals",
         "input_validation"
       ],
-      "unlocked_by": "null",
+      "unlocked_by": null,
       "uuid": "e24451fd-761d-4d20-81d9-e470486ec44a"
     },
     {


### PR DESCRIPTION
## Problem
While linting with the next release of [Configlet](https://github.com/exercism/configlet/releases/tag/v3.8.0) a number of exercises were still found to contain invalid unlocked_by configurations.

## What's changed
The master config file was updated in the following manner:

1. Any exercise containing the unlocked_by value of `"null"` was updated with a null value.

## Testing Steps
1.Download the pre-release of Configlet [here](https://github.com/exercism/configlet/releases/tag/v3.8.0)
1.Run `configlet lint <path-to-track>`
1.Validate that there are no lint errors.

closes #164 