### PR TITLE
removed 'version' line from luhn test

### DIFF
--- a/exercises/luhn/luhn_test.sh
+++ b/exercises/luhn/luhn_test.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-# Version = 1.2.0
-
 @test "single digit strings can not be valid" {
   #skip
   run bash luhn.sh "1"


### PR DESCRIPTION
<!-- Your content goes here: -->
Since my last PR revealed that the version should not be represented in the test file I checked which ones have it from my templates. It appears that it was only in the luhn exercise.

This PR fixes that.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
