### PR TITLE
Fix typo in hello world README.md

### DIFF
--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -23,7 +23,7 @@ likely going through bash.
 
 The downside to this is that there isn't much of a development
 ecosystem around bash like there is for other languages, and there are
-multiple verions of bash that can be frustratingly incompatible. Luckily
+multiple versions of bash that can be frustratingly incompatible. Luckily
 we shouldn't hit those differences for these basic examples, and if you
 can get the tests to pass on your machine, we are doing great.
 


### PR DESCRIPTION
<!-- Your content goes here: -->
Line 26 of README.md reads "verions"  instead of "versions." 

Obviously, this is a major issue that will cause bash newbies to be thrown off completely.

I have now fixed this, so you can all rest easy again.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)