### PR TITLE
Hamming: changed string to strand in hamming_test.sh and example.sh

### DIFF
--- a/exercises/hamming/example.sh
+++ b/exercises/hamming/example.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 <string1> <string2>" >&2
+  echo "Usage: $0 <strand1> <strand2>" >&2
   exit 1
 fi
 

--- a/exercises/hamming/hamming_test.sh
+++ b/exercises/hamming/hamming_test.sh
@@ -109,5 +109,5 @@
   skip
   run bash hamming.sh
   [ "$status" -eq 1 ]
-  [ "$output" == "Usage: hamming.sh <string1> <string2>" ]
+  [ "$output" == "Usage: hamming.sh <strand1> <strand2>" ]
 }


### PR DESCRIPTION
<!-- Your content goes here: -->
@kotp and I had a discussion regarding the inaccuracy of:
  '<*string*1> <*string*2>' in `Usage: <string1> <string2>`

I changed it to `Usage: <strand1> <strand2>` so it would better fit the context.

This change uses the input names from the [canonical-data.json](https://github.com/exercism/problem-specifications/blob/master/exercises/hamming/canonical-data.json) for hamming.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
