### PR TITLE
Remove obsolete information from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,3 @@ Exercism Exercises in Bash
 ## Contributing Guide
 
 Please see the [contributing guide](https://github.com/exercism/bash/blob/master/CONTRIBUTING.md) for information.
-
-
-### Bash icon
-We are using an unofficial logo of the GNU Bash project created by Justin Dorfman. It's not clear under which terms it's released. We believe that our adaptation, changing the colours, falls under fair use.


### PR DESCRIPTION
Exercism now uses the official logo: https://github.com/odb/official-bash-logo