### PR TITLE
armstrong-numbers: Replaced return status '1' with '0' for tests that expect false result

### DIFF
--- a/exercises/armstrong-numbers/armstrong_numbers_test.sh
+++ b/exercises/armstrong-numbers/armstrong_numbers_test.sh
@@ -12,7 +12,7 @@
   skip
   run bash armstrong_numbers.sh 10
 
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 }
 
@@ -28,7 +28,7 @@
   skip
   run bash armstrong_numbers.sh 100
 
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 }
 
@@ -44,7 +44,7 @@
   skip
   run bash armstrong_numbers.sh 9475
 
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 }
 
@@ -60,7 +60,7 @@
   skip
   run bash armstrong_numbers.sh 9926314
 
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 0 ]
   [ "$output" = "false" ]
 }
 

--- a/exercises/armstrong-numbers/example.sh
+++ b/exercises/armstrong-numbers/example.sh
@@ -15,11 +15,11 @@ is_armstrong() {
 
   if [ $sum -eq $number ]; then
     echo "true"
-    exit 0
   else
     echo "false"
-    exit 1
   fi
+
+  exit 0
 }
 
 is_armstrong "$@"


### PR DESCRIPTION
Applies the consistent exit codes rule discussed in the #241 (Although it seems that only `armstrong-numbers` broke them).

Closes #241 

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
