### PR TITLE
Update bob_test.sh: improve ambiguous whitespace tests

### DIFF
--- a/exercises/bob/bob_test.sh
+++ b/exercises/bob/bob_test.sh
@@ -135,14 +135,14 @@
 
 @test "alternate silence" {
   skip
-  run bash bob.sh "\t\t\t\t\t\t\t\t\t\t"
+  run bash bob.sh $'\t\t\t\t\t\t\t\t\t\t'
   [ "$status" -eq 0 ]
   [ "$output" == "Fine. Be that way!" ]
 }
 
 @test "multiple line question" {
   skip
-  run bash bob.sh "\nDoes this cryogenic chamber make me look fat?\nno"
+  run bash bob.sh $'\nDoes this cryogenic chamber make me look fat?\nno'
   [ "$status" -eq 0 ]
   [ "$output" == "Whatever." ]
 }
@@ -163,7 +163,7 @@
 # This test might act differently depending on your platform
 @test "other whitespace" {
   skip
-  run bash bob.sh "\n\r \t"
+  run bash bob.sh $'\n\r \t'
   [ "$status" -eq 0 ]
   [ "$output" == "Fine. Be that way!" ]
 }


### PR DESCRIPTION
Currently the tests send "\n" and "\t" to test talking to Bob with only whitespace.  A student brought it up that they probably should be sending actual, expanded tabs and newlines.  Using `$'dollar single quotes'` allows Bash to expand the escape codes before sending them to `bob.sh`.  (Generally, using `echo` does this for us, but we're running 

```bash
$ bash bob.sh "\n\t\r"
```

not using `echo` so they don't get expanded.)

Bonus: this lets students use the `[[:space:]]` character class in their solutions, which is nice and clean.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
