### PR TITLE
triangle: Fix duplicate test names

### DIFF
--- a/exercises/triangle/triangle_test.sh
+++ b/exercises/triangle/triangle_test.sh
@@ -2,21 +2,21 @@
 
 # Test returns true if the triangle is equilateral
 
-@test "true if all sides are equal" {
+@test "A triangle is equilateral if all sides are equal" {
   #skip
   run bash triangle.sh equilateral 2 2 2
   [ "$status" -eq 0 ]
   [ "$output" == "true" ]
 }
 
-@test "false if any side is unequal" {
+@test "A triangle is not equilateral if any side is unequal" {
   skip
   run bash triangle.sh equilateral 2 3 2
   [ "$status" -eq 0 ]
   [ "$output" == "false" ]
 }
 
-@test "false if no sides are equal" {
+@test "A triangle is not equilateral if no sides are equal" {
   skip
   run bash triangle.sh equilateral 5 4 6
   [ "$status" -eq 0 ]
@@ -32,7 +32,7 @@
 
 # Bonus: deal with floats
 
-@test "sides may be floats" {
+@test "An equilateral triangle may have sides which are decimal numbers" {
   skip
   run bash triangle.sh equilateral 0.5 0.5 0.5
   [ "$status" -eq 0 ]
@@ -41,35 +41,35 @@
 
 # Test returns true if the triangle is isosceles
 
-@test "true if last two sides are equal" {
+@test "A triangle is an isosceles if the last two sides are equal" {
   skip
   run bash triangle.sh isosceles 3 4 4
   [ "$status" -eq 0 ]
   [ "$output" == "true" ]
 }
 
-@test "true if first two sides are equal" {
+@test "A triangle is isosceles if the first two sides are equal" {
   skip
   run bash triangle.sh isosceles 4 4 3
   [ "$status" -eq 0 ]
   [ "$output" == "true" ]
 }
 
-@test "true if first and last sides are equal" {
+@test "A triangle is isoceles if the first and last sides are equal" {
   skip
   run bash triangle.sh isosceles 4 3 4
   [ "$status" -eq 0 ]
   [ "$output" == "true" ]
 }
 
-@test "equilateral triangles are also isosceles" {
+@test "Equilateral triangles are also isosceles" {
   skip
   run bash triangle.sh isosceles 4 4 4
   [ "$status" -eq 0 ]
   [ "$output" == "true" ]
 }
 
-@test "false if no sides are equal" {
+@test "A triangle is not isosceles if no sides are equal" {
   skip
   run bash triangle.sh isosceles 2 3 4
   [ "$status" -eq 0 ]
@@ -85,7 +85,7 @@
 
 # Bonus: deal with floats
 
-@test "sides may be floats" {
+@test "An isoscele triangle may have sides which are decimal numbers" {
   skip
   run bash triangle.sh isosceles 0.5 0.4 0.5
   [ "$status" -eq 0 ]
@@ -94,21 +94,21 @@
 
 # Test returns true if the triangle is scalene
 
-@test "true if no sides are equal" {
+@test "A triangle is scalene if it has no sides which are equal" {
   skip
   run bash triangle.sh scalene 5 4 6
   [ "$status" -eq 0 ]
   [ "$output" == "true" ]
 }
 
-@test "false if all sides are equal" {
+@test "A triangle is not scalene if all sides are equal" {
   skip
   run bash triangle.sh scalene 4 4 4
   [ "$status" -eq 0 ]
   [ "$output" == "false" ]
 }
 
-@test "false if two sides are equal" {
+@test "A triangle is not scalene if two sides are equal" {
   skip
   run bash triangle.sh scalene 4 4 3
   [ "$status" -eq 0 ]
@@ -124,7 +124,7 @@
 
 # Bonus: deal with floats
 
-@test "sides may be floats" {
+@test "A scalene triangle may have sides which are decimal numbers" {
   skip
   run bash triangle.sh scalene 0.5 0.4 0.6
   [ "$status" -eq 0 ]


### PR DESCRIPTION
Fixes the issue with duplicate test names in triangle_test.sh 

Tests with duplicate names are replaced silently by the testing framework. If there are three tests with the same name, they are actually all only the last one.

This patch renames most of the tests to be more descriptive and unique.
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
