### PR TITLE
acronym: change quotes

### DIFF
--- a/exercises/acronym/example.sh
+++ b/exercises/acronym/example.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$#" -ne 1 ]; then
-  echo Usage: $0 "'<phrase1>'" >&2
+  echo "Usage: $0 '<phrase1>'" >&2
   exit 1
 fi
 

--- a/exercises/acronym/example.sh
+++ b/exercises/acronym/example.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$#" -ne 1 ]; then
-  echo 'Usage: $0 "<phrase1>"' >&2
+  echo Usage: $0 "'<phrase1>'" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Change quotes to get correct instructional message e.g. "Usage: ./acronym.sh '<phrase>', 
instead of "Usage: $0 <phrase>"

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
