### PR TITLE
Mentor rpalo suggested a null user should work

### DIFF
--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -30,3 +30,11 @@
   [ "$status" -eq 1 ]
   [ "$output" = "Usage: ./error_handling <greetee>" ]
 }
+
+@test "empty argument" {
+  skip
+  run bash error_handling.sh ""
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "Hello, " ]
+}

--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -21,6 +21,7 @@
   run bash error_handling.sh Alice Bob
 
   [ "$status" -ne 0 ]
+  [ "$output" = "Usage: ./error_handling <greetee>" ]
 }
 
 @test "print usage banner with no value given" {

--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -20,7 +20,7 @@
   skip
   run bash error_handling.sh Alice Bob
 
-  [ "$status" -ne 0 ]
+  [ "$status" -eq 1 ]
   [ "$output" = "Usage: ./error_handling <greetee>" ]
 }
 


### PR DESCRIPTION
Since a null user should work and produce `Hello, ` as output, adding a test for it would make the implementation clearer.

I didn't find any `canonical-data.json` for the error-handling problem specification, so I added the test directly to the `error_handling_test.sh` file.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
