### PR TITLE
Adjust exercise difficulty for [forth, change, two-bucket]

### DIFF
--- a/config.json
+++ b/config.json
@@ -396,7 +396,7 @@
       "uuid": "9b62eb81-cf89-409e-a2e1-13bb0f411fd7",
       "core": false,
       "unlocked_by": "atbash-cipher",
-      "difficulty": 8,
+      "difficulty": 7,
       "topics": [
         "arrays",
         "control_flow_conditionals",
@@ -497,7 +497,7 @@
       "uuid": "febc47a2-4ee5-4cd7-be76-30aa105524c3",
       "core": false,
       "unlocked_by": "grains",
-      "difficulty": 9,
+      "difficulty": 8,
       "topics": [
         "arrays",
         "algorithms",
@@ -532,7 +532,7 @@
       "uuid": "769ce37b-21c5-4280-8b15-80ba4dac8ba5",
       "core": false,
       "unlocked_by": "hamming",
-      "difficulty": 6,
+      "difficulty": 9,
       "topics": [
         "associative_arrays",
         "control_flow_conditionals"


### PR DESCRIPTION
Current difficulties, sorted: http://ix.io/1Kwq
5: atbash-cipher
5: diffie-hellman
5: food-chain
5: grep
5: say
6: affine-cipher
6: two-bucket
8: forth
9: change

Based on my experience/solutions, this change updates the last three:
7: forth
8: change
9: two-bucket

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
