### PR TITLE
update validation script for safety

### DIFF
--- a/bin/validate_exercises
+++ b/bin/validate_exercises
@@ -6,29 +6,28 @@
 set -o errexit
 set -o nounset
 
-root_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
-temp_folder_name="exercises_temp/"
-temp_folder="$root_path/$temp_folder_name"
+temp_folder=$(mktemp -d) || { echo "cannot make temp dir"; exit 1; }
 
 # Clean up after script on normal or forced exit
-trap "{ rm -rf $temp_folder; }" EXIT
+cleanup() { rm -r "$temp_folder"; }
+trap cleanup EXIT
 
-cp exercises $temp_folder -r
-cd $temp_folder
+cd "$( dirname "${BASH_SOURCE[0]}" )/.."
+cp -r ./exercises/* "$temp_folder"
 
+cd "$temp_folder"
 for exercise in *; do
-  cd $exercise
+  cd "$exercise"
   echo "Processing $exercise"
 
   # Replace "-" with "_" to follow bash conventions
-  exercise_name=$(echo "$exercise" | sed -r 's/[-]+/_/g')
-  test_file=${exercise_name}_test.sh
+  exercise_name=${exercise//-/_}
 
   # Create implementation file from example
-  cp example.sh ${exercise_name}.sh
+  ln -f example.sh "${exercise_name}.sh"
 
   # Run the tests
-  BATS_RUN_SKIPPED=true bats $test_file
+  BATS_RUN_SKIPPED=true bats "${exercise_name}_test.sh"
 
   cd ../
 done

--- a/bin/validate_exercises
+++ b/bin/validate_exercises
@@ -6,6 +6,15 @@
 set -o errexit
 set -o nounset
 
+export BATS_RUN_SKIPPED=true    # run all the tests
+
+for tool in mktemp bats; do
+  if ! type -P "$tool" >/dev/null; then
+    echo "Can't find required tool: $tool" >&2
+    exit 1
+  fi
+done
+
 temp_folder=$(mktemp -d) || { echo "cannot make temp dir"; exit 1; }
 
 # Clean up after script on normal or forced exit
@@ -13,7 +22,9 @@ cleanup() { rm -r "$temp_folder"; }
 trap cleanup EXIT
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
-cp -r ./exercises/* "$temp_folder"
+
+# trailing slash: only copy directories
+cp -r ./exercises/*/ "$temp_folder"
 
 cd "$temp_folder"
 for exercise in *; do
@@ -27,7 +38,7 @@ for exercise in *; do
   ln -f example.sh "${exercise_name}.sh"
 
   # Run the tests
-  BATS_RUN_SKIPPED=true bats "${exercise_name}_test.sh"
+  bats "${exercise_name}_test.sh"
 
   cd ../
 done


### PR DESCRIPTION
<!-- Your content goes here: -->

So, I called the validate_exercises script, trying to see why the build is failing.
I did not have an "exercises_temp" directory: the `cd` failed, and the script delete my local "bash" repo.

sad face

Here's a safer version, using `mktemp` to create the tempdir. If you don't want to do that, at the very least add `mkdir -p "$temp_folder"` before trying to cd to it.

* The "cleanup" function is just my style, to make the `trap` call tidier.
* Using `ln` instead of `cp` will speed things up by a few milliseconds.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
