### PR TITLE
We should be doing string matching for output tests, not numeric

### DIFF
--- a/exercises/collatz-conjecture/collatz_conjecture_test.sh
+++ b/exercises/collatz-conjecture/collatz_conjecture_test.sh
@@ -4,28 +4,28 @@
   #[[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash collatz_conjecture.sh 1
   [[ $status -eq 0 ]]
-  [[ $output -eq 0 ]]
+  [[ $output == "0" ]]
 }
 
 @test "divide if even" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash collatz_conjecture.sh 16
   [[ $status -eq 0 ]]
-  [[ $output -eq 4 ]]
+  [[ $output == "4" ]]
 }
 
 @test "even and odd steps" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash collatz_conjecture.sh 12
   [[ $status -eq 0 ]]
-  [[ $output -eq 9 ]]
+  [[ $output == "9" ]]
 }
 
 @test "large number of even and odd steps" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash collatz_conjecture.sh 1000000
   [[ $status -eq 0 ]]
-  [[ $output -eq 152 ]]
+  [[ $output == "152" ]]
 }
 
 @test "zero is an error" {

--- a/exercises/hamming/hamming_test.sh
+++ b/exercises/hamming/hamming_test.sh
@@ -4,35 +4,35 @@
   #[[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh '' ''
   [[ $status -eq 0 ]]
-  [[ $output -eq 0 ]]
+  [[ $output == "0" ]]
 }
 
 @test 'single letter identical strands' {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh 'A' 'A'
   [[ $status -eq 0 ]]
-  [[ $output -eq 0 ]]
+  [[ $output == "0" ]]
 }
 
 @test 'single letter different strands' {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh 'G' 'T'
   [[ $status -eq 0 ]]
-  [[ $output -eq 1 ]]
+  [[ $output == "1" ]]
 }
 
 @test 'long identical strands' {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh 'GGACTGAAATCTG' 'GGACTGAAATCTG'
   [[ $status -eq 0 ]]
-  [[ $output -eq 0 ]]
+  [[ $output == "0" ]]
 }
 
 @test 'long different strands' {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh 'GGACGGATTCTG' 'AGGACGGATTCT'
   [[ $status -eq 0 ]]
-  [[ $output -eq 9 ]]
+  [[ $output == "9" ]]
 }
 
 @test 'disallow first strand longer' {

--- a/exercises/knapsack/knapsack_test.sh
+++ b/exercises/knapsack/knapsack_test.sh
@@ -18,47 +18,47 @@
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 100
     [[ $status -eq 0 ]]
-    [[ $output -eq 0 ]]
+    [[ $output == "0" ]]
 }
 
 @test "one item: too heavy" {
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 10 100:1
     [[ $status -eq 0 ]]
-    [[ $output -eq 0 ]]
+    [[ $output == "0" ]]
 }
 
 @test "five items (cannot be greedy by weight)" {
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 10 2:5 2:5 2:5 2:5 10:21
     [[ $status -eq 0 ]]
-    [[ $output -eq 21 ]]
+    [[ $output == "21" ]]
 }
 
 @test "five items (cannot be greedy by value)" {
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 10 2:20 2:20 2:20 2:20 10:50
     [[ $status -eq 0 ]]
-    [[ $output -eq 80 ]]
+    [[ $output == "80" ]]
 }
 
 @test "example knapsack" {
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 10 5:10 4:40 6:30 4:50
     [[ $status -eq 0 ]]
-    [[ $output -eq 90 ]]
+    [[ $output == "90" ]]
 }
 
 @test "8 items" {
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 104 25:350 35:400 45:450 5:20 25:70 3:8 2:5 2:5
     [[ $status -eq 0 ]]
-    [[ $output -eq 900 ]]
+    [[ $output == "900" ]]
 }
 
 @test "15 items" {
     [[ $BATS_RUN_SKIPPED = true ]] || skip
     run bash knapsack.sh 750 70:135 73:139 77:149 80:150 82:156 87:163 90:173 94:184 98:192 106:201 110:210 113:214 115:221 118:229 120:240
     [[ $status -eq 0 ]]
-    [[ $output -eq 1458 ]]
+    [[ $output == "1458" ]]
 }

--- a/exercises/scrabble-score/scrabble_score_test.sh
+++ b/exercises/scrabble-score/scrabble_score_test.sh
@@ -5,7 +5,7 @@
   run bash scrabble_score.sh 'a'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 1 ]]
+  [[ $output == "1" ]]
 }
 
 @test 'uppercase letter' {
@@ -13,7 +13,7 @@
   run bash scrabble_score.sh 'A'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 1 ]]
+  [[ $output == "1" ]]
 }
 
 @test 'valuable letter' {
@@ -21,7 +21,7 @@
   run bash scrabble_score.sh 'f'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 4 ]]
+  [[ $output == "4" ]]
 }
 
 @test 'short word' {
@@ -29,7 +29,7 @@
   run bash scrabble_score.sh 'at'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 2 ]]
+  [[ $output == "2" ]]
 }
 
 @test 'short, valuable word' {
@@ -37,7 +37,7 @@
   run bash scrabble_score.sh 'zoo'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 12 ]]
+  [[ $output == "12" ]]
 }
 
 @test 'medium word' {
@@ -45,7 +45,7 @@
   run bash scrabble_score.sh 'street'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 6 ]]
+  [[ $output == "6" ]]
 }
 
 @test 'medium, valuable word' {
@@ -53,7 +53,7 @@
   run bash scrabble_score.sh 'quirky'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 22 ]]
+  [[ $output == "22" ]]
 }
 
 @test 'long, mixed-case word' {
@@ -61,7 +61,7 @@
   run bash scrabble_score.sh 'OxyphenButazone'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 41 ]]
+  [[ $output == "41" ]]
 }
 
 @test 'english-like word' {
@@ -69,7 +69,7 @@
   run bash scrabble_score.sh 'pinata'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 8 ]]
+  [[ $output == "8" ]]
 }
 
 @test 'empty input' {
@@ -77,7 +77,7 @@
   run bash scrabble_score.sh ''
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 0 ]]
+  [[ $output == "0" ]]
 }
 
 @test 'entire alphabet available' {
@@ -85,5 +85,5 @@
   run bash scrabble_score.sh 'abcdefghijklmnopqrstuvwxyz'
   
   [[ $status -eq 0 ]]
-  [[ $output -eq 87 ]]
+  [[ $output == "87" ]]
 }


### PR DESCRIPTION
<!-- Your content goes here: -->
I was reviewing a solution where the student was outputting an empty string, but the `[[ $output -eq 0 ]]` test was passing. My recent fix to use double brackets introduced this regression:

```
$ output=""
$ [ "$output" -eq 0 ] && echo y || echo n
bash: [: : integer expression expected
n
$ [[ $output -eq 0 ]] && echo y || echo n
y
$ [[ $output == "0" ]] && echo y || echo n
n
```

This fix updates all uses of `[[ $output -eq some_number ]]`


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
