### PR TITLE
WIP: Convert to Lib tests

### DIFF
--- a/exercises/triangle/example.sh
+++ b/exercises/triangle/example.sh
@@ -1,18 +1,13 @@
 #!/usr/bin/env bash
 
 set -o errexit   # Stop script on command error
-set -o nounset   # Error out if accessing undefined variable name
+#set -o nounset   # Error out if accessing undefined variable name
 set -o pipefail  # Error out if any step in a pipe errors out
 
-if [[ $# -ne 4 ]]; then
+usage () {
   echo "Usage: $0 [equilateral | isosceles | scalene] <s1> <s2> <s3>"
   exit 2 # Improper inputs
-fi
-
-triangle_type=$1
-s1=$2
-s2=$3
-s3=$4
+}
 
 assert() {
   # Takes a numerical inequality in a string.
@@ -22,14 +17,7 @@ assert() {
 }
 
 output() {
-  exit_code=$1
-
-  if [ $exit_code -eq 0 ]; then
-    echo "true"
-  else
-    echo "false"
-  fi
-
+  [[ $1 -eq 0 ]] && echo 'true' || echo 'false'
   exit 0
 }
 
@@ -43,34 +31,28 @@ valid_triangle() {
   return 0
 }
 
-if ! valid_triangle $s1 $s2 $s3; then
-  # Sides do not meet triangle inequality requirement
-  # Given a <= b <= c and a, b, c != 0, a + b >= c
-  output 1
-fi
+validate_args () {
+  [[ $# -eq 3 ]] || usage
+  valid_triangle "$@"
+}
 
 equilateral() {
+  validate_args "$@" || output 1
   assert "$1 == $2" && assert "$1 == $3"
 
   output $?
 }
 
 isosceles() {
+  validate_args "$@" || output 1
   assert "$1 == $2" || assert "$1 == $3" || assert "$2 == $3"
 
   output $?
 }
 
 scalene() {
+  validate_args "$@" || output 1
   assert "$1 != $2" && assert "$1 != $3" && assert "$2 != $3"
 
   output $?
 }
-
-# Bash Ternary Operator:
-# (boolean value/calculation) && action if true || action if false
-# Works because of boolean shortcutting.
-# If boolean clause is false, it doesn't evaluate the other side of &&
-# If first thing is false, it evaluates the item after ||,
-# but if first two are true, doesn't bother evaluating last part.
-$triangle_type $s1 $s2 $s3 && exit 0 || exit 1

--- a/exercises/triangle/triangle.sh
+++ b/exercises/triangle/triangle.sh
@@ -1,24 +1,13 @@
 #!/usr/bin/env bash
 
-# The following comments should help you get started:
-# - Bash is flexible. You may use functions or write a "raw" script.
-#
-# - Complex code can be made easier to read by breaking it up
-#   into functions, however this is sometimes overkill in bash.
-#
-# - You can find links about good style and other resources
-#   for Bash in './README.md'. It came with this exercise.
-#
-#   Example:
-#   # other functions here
-#   # ...
-#   # ...
-#
-#   main () {
-#     # your main function code here
-#   }
-#
-#   # call main with all of the positional arguments
-#   main "$@"
-#
-# *** PLEASE REMOVE THESE COMMENTS BEFORE SUBMITTING YOUR SOLUTION ***
+equilateral() {
+  echo 'unimplemented!'
+}
+
+isosceles() {
+  echo 'unimplemented!'
+}
+
+scalene() {
+  echo 'unimplemented!'
+}

--- a/exercises/triangle/triangle_test.sh
+++ b/exercises/triangle/triangle_test.sh
@@ -1,31 +1,34 @@
 #!/usr/bin/env bash
 
+# get user code
+source triangle.sh
+
 # Test returns true if the triangle is equilateral
 
 @test "all sides are equal, equilateral" {
   #[[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh equilateral 2 2 2
+  run equilateral 2 2 2
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
 
 @test "any side is unequal" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh equilateral 2 3 2
+  run equilateral 2 3 2
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "no sides are equal, equilateral" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh equilateral 5 4 6
+  run equilateral 5 4 6
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "all zero sides is not a triangle" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh equilateral 0 0 0
+  run equilateral 0 0 0
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
@@ -34,7 +37,7 @@
 
 @test "sides may be floats, equilateral" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh equilateral 0.5 0.5 0.5
+  run equilateral 0.5 0.5 0.5
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
@@ -43,56 +46,56 @@
 
 @test "last two sides are equal" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 3 4 4
+  run isosceles 3 4 4
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
 
 @test "first two sides are equal" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 4 4 3
+  run isosceles 4 4 3
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
 
 @test "first and last sides are equal" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 4 3 4
+  run isosceles 4 3 4
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
 
 @test "equilateral triangles are also isosceles" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 4 4 4
+  run isosceles 4 4 4
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
 
 @test "no sides are equal, isosceles" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 2 3 4
+  run isosceles 2 3 4
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "first triangle inequality violation" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 1 1 3
+  run isosceles 1 1 3
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "second triangle inequality violation" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 1 1 3
+  run isosceles 1 1 3
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "third triangle inequality violation" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 1 1 3
+  run isosceles 1 1 3
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
@@ -101,7 +104,7 @@
 
 @test "sides may be floats, isosceles" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh isosceles 0.5 0.4 0.5
+  run isosceles 0.5 0.4 0.5
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
@@ -110,28 +113,28 @@
 
 @test "no sides are equal, scalene" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh scalene 5 4 6
+  run scalene 5 4 6
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }
 
 @test "all sides are equal, scalene" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh scalene 4 4 4
+  run scalene 4 4 4
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "two sides are equal" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh scalene 4 4 3
+  run scalene 4 4 3
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
 
 @test "may not violate triangle inequality" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh scalene 7 3 2
+  run scalene 7 3 2
   [[ $status -eq 0 ]]
   [[ $output == "false" ]]
 }
@@ -140,7 +143,7 @@
 
 @test "sides may be floats, scalene" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash triangle.sh scalene 0.5 0.4 0.6
+  run scalene 0.5 0.4 0.6
   [[ $status -eq 0 ]]
   [[ $output == "true" ]]
 }

--- a/exercises/two-fer/example.sh
+++ b/exercises/two-fer/example.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-if [ "$#" -eq 0 ]; then
-  person="you"
-else
-  person="$1"
-fi
-
-echo "One for $person, one for me."
+two_fer () {
+  echo "One for ${1:-you}, one for me."
+}

--- a/exercises/two-fer/two_fer.sh
+++ b/exercises/two-fer/two_fer.sh
@@ -1,24 +1,5 @@
 #!/usr/bin/env bash
 
-# The following comments should help you get started:
-# - Bash is flexible. You may use functions or write a "raw" script.
-#
-# - Complex code can be made easier to read by breaking it up
-#   into functions, however this is sometimes overkill in bash.
-#
-# - You can find links about good style and other resources
-#   for Bash in './README.md'. It came with this exercise.
-#
-#   Example:
-#   # other functions here
-#   # ...
-#   # ...
-#
-#   main () {
-#     # your main function code here
-#   }
-#
-#   # call main with all of the positional arguments
-#   main "$@"
-#
-# *** PLEASE REMOVE THESE COMMENTS BEFORE SUBMITTING YOUR SOLUTION ***
+two_fer () {
+  echo 'unimplemented!'
+}

--- a/exercises/two-fer/two_fer_test.sh
+++ b/exercises/two-fer/two_fer_test.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# access user code
+source two_fer.sh
+
 @test "no name given" {
   #[[ $BATS_RUN_SKIPPED == true  ]] || skip
 
@@ -16,28 +19,28 @@
   #
   #     $ BATS_RUN_SKIPPED=true bats two_fer_test.sh
 
-  run bash two_fer.sh
+  run two_fer
   [[ $status -eq 0 ]]
   [[ $output == "One for you, one for me." ]]
 }
 
 @test "a name given" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash two_fer.sh Alice
+  run two_fer Alice
   [[ $status -eq 0 ]]
   [[ $output == "One for Alice, one for me." ]]
 }
 
 @test "another name given" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash two_fer.sh Bob
+  run two_fer Bob
   [[ $status -eq 0 ]]
   [[ $output == "One for Bob, one for me." ]]
 }
 
 @test "handle arg1 properly" {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
-  run bash two_fer.sh "John Smith" "Mary Ann"
+  run two_fer "John Smith" "Mary Ann"
   [[ $status -eq 0 ]]
   [[ $output == "One for John Smith, one for me." ]]
 }


### PR DESCRIPTION
<!-- Your content goes here: -->
This is not intended for merging at all, but rather it is intended to share ideas about how to convert our tests to library testing.  That being said, if commits only ever involve 1 exercise, then we can easily cherry pick conversions where we agree, so they can be merged in their own PR.

For now, I just did `two-fer` initial PoC and `triangle` since it is a bit more relevant.

@glennj I played with the `::` you used for name spacing in `forth`, but I could not get it to work for `triangle`. It kept returning an error status.  Anyway, I will keep investigating that, but any investigation you feel like doing would be appreciated.

I noticed that `nounset` absolutely may not be used in the implementation files for lib testing.  `source`ing the file into bats, then pollutes the bats environment.  Since bats relies on variables being unset sometimes it will not work.  We can probably use something like `bash -c "source triangle; equilateral 2 2 2"` to keep from polluting the bats environment.  We should make sure we discuss this ;)

closes #366



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
