### PR TITLE
Hamming: streamline error messages

### DIFF
--- a/exercises/hamming/example.sh
+++ b/exercises/hamming/example.sh
@@ -22,11 +22,7 @@ trap __at_exit_cleanup EXIT
 str1="$1"
 str2="$2"
 
-
-[[ -z $str1 && -n $str2 ]] && die "left strand must not be empty"
-[[ -n $str1 && -z $str2 ]] && die "right strand must not be empty"
 (( ${#str1} != ${#str2} )) && die "left and right strands must be of equal length"
-
 
 echo "$str1" | fold -w1 > $file1
 echo "$str2" | fold -w1 > $file2

--- a/exercises/hamming/hamming_test.sh
+++ b/exercises/hamming/hamming_test.sh
@@ -53,14 +53,14 @@
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh '' 'G'
   [[ $status -eq 1 ]]
-  [[ $output == 'left strand must not be empty' ]]
+  [[ $output == 'left and right strands must be of equal length' ]]
 }
 
 @test 'disallow right empty strand' {
   [[ $BATS_RUN_SKIPPED == true  ]] || skip
   run bash hamming.sh 'G' ''
   [[ $status -eq 1 ]]
-  [[ $output == 'right strand must not be empty' ]]
+  [[ $output == 'left and right strands must be of equal length' ]]
 }
 
 @test "no input" {


### PR DESCRIPTION
<!-- Your content goes here: -->

This change consolidates the different error messages into 1 while still keeping all the test scenarios.

Looking at the history of the canonical-data, there was an edge case for recursive solutions in Haskell where left/right empty input was not picked up. They chose to use specific error messages for these situations.

They don't really add any value for learning bash.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
