### PR TITLE
diffie-helman: bash 3.2 error in test file

### DIFF
--- a/exercises/diffie-hellman/diffie_hellman_test.sh
+++ b/exercises/diffie-hellman/diffie_hellman_test.sh
@@ -14,7 +14,6 @@
 @test "private key is random" {
     [[ $BATS_RUN_SKIPPED == true  ]] || skip
     # may fail due to randomness
-    local -A keys=()
     local -i n=10 p=32000
     for i in $(seq $n); do
         run bash diffie_hellman.sh privateKey $p


### PR DESCRIPTION
<!-- Your content goes here: -->

unnecessary and unused associative array declaration in test file gives error for older bash.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
