### PR TITLE
simple-cipher: issue with extglob in test file

### DIFF
--- a/exercises/simple-cipher/simple_cipher_test.sh
+++ b/exercises/simple-cipher/simple_cipher_test.sh
@@ -11,8 +11,7 @@
     [[ $status -eq 0 ]]
     key=$output
     [[ ${#key} -ge 100 ]]     # at least 100 chars
-    shopt -s extglob
-    [[ $key == +([[:lower:]]) ]]    # only lowercase letters
+    [[ $key != [^[:lower:]] ]]    # only lowercase letters
 }
 
 @test  "Can encode random" {


### PR DESCRIPTION

<!-- Your content goes here: -->

Running with bats-core and bash 3.2, the extended pattern in the first test errored.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
