### PR TITLE
resistor-color-trio: tests for invalid octal, extra colors

### DIFF
--- a/exercises/resistor-color-trio/resistor_color_trio_test.sh
+++ b/exercises/resistor-color-trio/resistor_color_trio_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# local version: 1.0.0.1
-# additional tests for invalid color
+# local version: 1.0.0.2
+# additional tests for: invalid color, invalid octal number, too many colors
 
 @test "Orange and orange and black" {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
@@ -86,4 +86,18 @@
     run bash resistor_color_trio.sh "white" "white" "baz"
     [[ $status -eq 1 ]]
     [[ -n $output ]]
+}
+
+@test "First two colors make an invalid octal number" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run bash resistor_color_trio.sh "black" "grey" "black"
+    [[ $status -eq 0 ]]
+    [[ $output == "8 ohms" ]]
+}
+
+@test "Ignore extra colors" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run bash resistor_color_trio.sh "blue" "green" "yellow" "orange"
+    [[ $status -eq 0 ]]
+    [[ $output == "650 kiloohms" ]]
 }


### PR DESCRIPTION
<!-- Your content goes here: -->

A couple of extra tests to force solutions to handle awkward input.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
