### PR TITLE
Added bats install instructions for windows / cygwin

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -28,8 +28,7 @@ $ git clone https://github.com/sstephenson/bats.git
 $ cd bats
 $ ./install.sh $HOME
 ```
-If you discover an error like `cp: cannot create symbolic link '/c/Users/XXX/bin/bats': No such file or directory`,
-you have to copy the `bin/bats/libexec/` folder content to `/c/Users/XXX/bin/` manually.
+If you discover an error like `cp: cannot create symbolic link '${HOME}/bin/bats': No such file or directory`, you have to copy the `bin/bats/libexec/` folder content to `${HOME}/bin/` manually.
 
 ---
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -24,11 +24,11 @@ sudo yum install bats
 
 ### For Windows (MINGW64/Cygwin)
 ```
-$ git clone https://github.com/sstephenson/bats.git
+$ git clone https://github.com/bats-core/bats-core.git
 $ cd bats
 $ ./install.sh $HOME
 ```
-If you discover an error like `cp: cannot create symbolic link '${HOME}/bin/bats': No such file or directory`, you have to copy the `bin/bats/libexec/` folder content to `${HOME}/bin/` manually.
+Note: When you are using the outdated `https://github.com/sstephenson/bats.git` and you discover an error like `cp: cannot create symbolic link '${HOME}/bin/bats': No such file or directory`, you have to copy the `bin/bats/libexec/` folder content to `${HOME}/bin/` manually.
 
 ---
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,5 +1,6 @@
 As there isn't much of a bash ecosystem, there also isn't really a defacto leader in the bash testing area. For these examples we are using [bats](https://github.com/sstephenson/bats). You should be able to install it from your favorite package manager, on OS X with homebrew this would look something like this:
 
+### For Mac (brew)
 ```
 $ brew install bats
 ==> Downloading
@@ -11,14 +12,25 @@ https://codeload.github.com/sstephenson/bats/tar.gz/v0.4.0
 /opt/boxen/homebrew/Cellar/bats/0.4.0: 10 files, 60K, built in 2 seconds  
 ```
 
-For Ubuntu 15.10 or later  
+### For Ubuntu 15.10 or later  
 ```
 sudo apt-get install bats  
 ```
 
-For Red Hat, Scientific Linux, and CentOS 6 or later bats is found in the EPEL repository.  
+### For Red Hat, Scientific Linux, and CentOS 6 or later bats is found in the EPEL repository.  
 ```
 sudo yum install bats  
 ```
+
+### For Windows (MINGW64/Cygwin)
+```
+$ git clone https://github.com/sstephenson/bats.git
+$ cd bats
+$ ./install.sh $HOME
+```
+If you discover an error like `cp: cannot create symbolic link '/c/Users/XXX/bin/bats': No such file or directory`,
+you have to copy the `bin/bats` symbolic link to `/c/Users/XXX/bin/bats` manually.
+
+---
 
 Run the tests with `bats whatever_test.sh` or `./whatever_test.sh`.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -29,7 +29,7 @@ $ cd bats
 $ ./install.sh $HOME
 ```
 If you discover an error like `cp: cannot create symbolic link '/c/Users/XXX/bin/bats': No such file or directory`,
-you have to copy the `bin/bats` symbolic link to `/c/Users/XXX/bin/bats` manually.
+you have to copy the `bin/bats/libexec/` folder content to `/c/Users/XXX/bin/` manually.
 
 ---
 


### PR DESCRIPTION
Added `bats` install instructions for windows under Cygwin / MINGW64


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
