### PR TITLE
Fix topic names

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "strings",
         "text_formatting"
       ]
@@ -33,7 +33,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "error_handling",
+        "exception_handling",
         "input_validation",
         "strings"
       ]
@@ -45,7 +45,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "input_validation",
         "strings"
       ]
@@ -57,8 +57,8 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "control_flow_loops",
-        "string_comparison"
+        "loops",
+        "equality"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "difficulty": 3,
       "topics": [
         "input_validation",
-        "string_transformation",
+        "transforming",
         "strings"
       ]
     },
@@ -91,7 +91,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "string_transformation",
+        "transforming",
         "strings"
       ]
     },
@@ -102,7 +102,7 @@
       "unlocked_by": null,
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "strings"
       ]
     },
@@ -124,7 +124,7 @@
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "input_validation",
         "integers",
         "math"
@@ -147,8 +147,8 @@
       "unlocked_by": "armstrong-numbers",
       "difficulty": 2,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "math"
       ]
     },
@@ -159,8 +159,9 @@
       "unlocked_by": "hello-world",
       "difficulty": 2,
       "topics": [
-        "boolean_logic",
-        "control_flow_conditionals",
+        "booleans",
+        "logic",
+        "conditionals",
         "input_validation"
       ]
     },
@@ -171,9 +172,9 @@
       "unlocked_by": "pangram",
       "difficulty": 2,
       "topics": [
-        "associative_arrays",
-        "control_flow_loops",
-        "error_handling"
+        "arrays",
+        "loops",
+        "exception_handling"
       ]
     },
     {
@@ -183,9 +184,9 @@
       "unlocked_by": "pangram",
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
-        "string_transformation",
+        "conditionals",
+        "loops",
+        "transforming",
         "strings"
       ]
     },
@@ -196,7 +197,7 @@
       "unlocked_by": "grains",
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "input_validation",
         "integers",
         "math"
@@ -209,9 +210,9 @@
       "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
-        "error_handling",
-        "string_comparison"
+        "loops",
+        "exception_handling",
+        "equality"
       ]
     },
     {
@@ -221,10 +222,10 @@
       "unlocked_by": "pangram",
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
-        "error_handling",
-        "string_comparison",
-        "string_transformation"
+        "conditionals",
+        "exception_handling",
+        "equality",
+        "transforming"
       ]
     },
     {
@@ -234,10 +235,11 @@
       "unlocked_by": "armstrong-numbers",
       "difficulty": 3,
       "topics": [
-        "boolean_logic",
-        "error_handling",
+        "booleans",
+        "logic",
+        "exception_handling",
         "input_validation",
-        "number_comparison"
+        "equality"
       ]
     },
     {
@@ -247,8 +249,8 @@
       "unlocked_by": "pangram",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
-        "string_comparison",
+        "loops",
+        "equality",
         "strings"
       ]
     },
@@ -270,7 +272,7 @@
       "difficulty": 4,
       "topics": [
         "algorithms",
-        "control_flow_conditionals",
+        "conditionals",
         "integers"
       ]
     },
@@ -318,7 +320,7 @@
       "unlocked_by": "pangram",
       "difficulty": 3,
       "topics": [
-        "regexp",
+        "regular_expressions",
         "strings"
       ]
     },
@@ -330,7 +332,7 @@
       "difficulty": 4,
       "topics": [
         "loops",
-        "string_transformation",
+        "transforming",
         "strings"
       ]
     },
@@ -343,7 +345,7 @@
       "topics": [
         "algorithms",
         "integers",
-        "string_transformation"
+        "transforming"
       ]
     },
     {
@@ -376,7 +378,7 @@
       "unlocked_by": "scrabble-score",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "text_formatting"
       ]
     },
@@ -387,7 +389,7 @@
       "unlocked_by": "scrabble-score",
       "difficulty": 5,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "text_formatting"
       ]
     },
@@ -399,10 +401,10 @@
       "difficulty": 7,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
-        "error_handling",
+        "conditionals",
+        "exception_handling",
         "input_validation",
-        "string_comparison"
+        "equality"
       ]
     },
     {
@@ -413,7 +415,7 @@
       "difficulty": 2,
       "topics": [
         "arrays",
-        "control_flow_conditionals"
+        "conditionals"
       ]
     },
     {
@@ -424,7 +426,7 @@
       "difficulty": 3,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
+        "conditionals",
         "math"
       ]
     },
@@ -467,7 +469,7 @@
       "unlocked_by": "two-fer",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "strings"
       ]
     },
@@ -479,7 +481,7 @@
       "difficulty": 2,
       "topics": [
         "arrays",
-        "control_flow_conditionals"
+        "conditionals"
       ]
     },
     {
@@ -489,7 +491,7 @@
       "unlocked_by": "two-fer",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "text_formatting"
       ]
     },
@@ -500,7 +502,7 @@
       "unlocked_by": "scrabble-score",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "text_formatting"
       ]
     },
@@ -546,8 +548,8 @@
       "unlocked_by": "hamming",
       "difficulty": 9,
       "topics": [
-        "associative_arrays",
-        "control_flow_conditionals"
+        "arrays",
+        "conditionals"
       ]
     },
     {
@@ -568,8 +570,8 @@
       "unlocked_by": "armstrong-numbers",
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "math"
       ]
     },
@@ -580,7 +582,7 @@
       "unlocked_by": "hamming",
       "difficulty": 5,
       "topics": [
-        "string_transformation"
+        "transforming"
       ]
     },
     {
@@ -612,7 +614,7 @@
       "difficulty": 3,
       "topics": [
         "arrays",
-        "control_flow_conditionals"
+        "conditionals"
       ]
     },
     {
@@ -622,8 +624,8 @@
       "unlocked_by": "hamming",
       "difficulty": 3,
       "topics": [
-        "associative_arrays",
-        "string_transformation"
+        "arrays",
+        "transforming"
       ]
     },
     {
@@ -633,7 +635,7 @@
       "unlocked_by": "grains",
       "difficulty": 2,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "math"
       ]
     },
@@ -677,8 +679,8 @@
       "unlocked_by": "pangram",
       "difficulty": 3,
       "topics": [
-        "associative_arrays",
-        "control_flow_loops"
+        "arrays",
+        "loops"
       ]
     },
     {
@@ -688,7 +690,7 @@
       "unlocked_by": "luhn",
       "difficulty": 3,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "math"
       ]
     },
@@ -712,7 +714,7 @@
       "difficulty": 6,
       "topics": [
         "conditionals",
-        "error_handling",
+        "exception_handling",
         "variables"
       ]
     },
@@ -759,7 +761,7 @@
       "unlocked_by": "acronym",
       "difficulty": 6,
       "topics": [
-        "control_flow_loops",
+        "loops",
         "parsing",
         "strings"
       ]
@@ -795,8 +797,8 @@
       "unlocked_by": "grains",
       "difficulty": 6,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "math"
       ]
     },
@@ -807,8 +809,8 @@
       "unlocked_by": "raindrops",
       "difficulty": 7,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "strings",
         "text_formatting"
       ]
@@ -821,7 +823,7 @@
       "difficulty": 6,
       "topics": [
         "input_validation",
-        "string_transformation"
+        "transforming"
       ]
     },
     {
@@ -831,7 +833,7 @@
       "unlocked_by": "hamming",
       "difficulty": 5,
       "topics": [
-        "string_transformation"
+        "transforming"
       ]
     },
     {
@@ -841,8 +843,8 @@
       "unlocked_by": "hamming",
       "difficulty": 5,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "input_validation"
       ]
     },
@@ -866,7 +868,7 @@
       "difficulty": 6,
       "topics": [
         "arrays",
-        "control_flow_loops",
+        "loops",
         "text_formatting"
       ]
     },
@@ -900,7 +902,7 @@
       "unlocked_by": "scrabble-score",
       "difficulty": 6,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "external_commands"
       ]
     },
@@ -924,7 +926,7 @@
       "topics": [
         "algorithms",
         "arrays",
-        "control_flow_loops"
+        "loops"
       ]
     },
     {
@@ -934,8 +936,8 @@
       "unlocked_by": "scrabble-score",
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
-        "error_handling",
+        "conditionals",
+        "exception_handling",
         "input_validation"
       ]
     },
@@ -947,7 +949,7 @@
       "difficulty": 8,
       "topics": [
         "arrays",
-        "control_flow_conditionals",
+        "conditionals",
         "integers",
         "sorting",
         "strings"
@@ -960,11 +962,11 @@
       "unlocked_by": "acronym",
       "difficulty": 8,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "cryptography",
         "input_validation",
-        "transformation"
+        "transforming"
       ]
     },
     {
@@ -977,7 +979,7 @@
         "arrays",
         "cryptography",
         "math",
-        "transformation"
+        "transforming"
       ]
     },
     {
@@ -987,8 +989,8 @@
       "unlocked_by": "raindrops",
       "difficulty": 8,
       "topics": [
-        "control_flow_conditionals",
-        "control_flow_loops",
+        "conditionals",
+        "loops",
         "strings"
       ]
     },
@@ -999,7 +1001,7 @@
       "unlocked_by": "two-fer",
       "difficulty": 3,
       "topics": [
-        "control_flow_conditionals",
+        "conditionals",
         "math"
       ]
     }


### PR DESCRIPTION
<!-- Your content goes here: -->
After viewing an [analysis of the topics on the Bash track](https://tracks.exercism.io/bash/master/topics), I noticed a lot of topics that weren't listed in [`exercism/problem-specifications/TOPICS.txt`](https://github.com/exercism/problem-specifications/blob/master/TOPICS.txt). This PR replaces most of those with valid topic names.

I'm always completely open to any changes.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
