### PR TITLE
add .meta/config.json files to each exercise for the test runner

### DIFF
--- a/exercises/acronym/.meta/config.json
+++ b/exercises/acronym/.meta/config.json
@@ -4,43 +4,43 @@
   ],
   "tests": [
     {
-      "name": "'basic'",
+      "name": "basic",
       "cmd": "bash acronym.sh 'Portable Network Graphics'"
     },
     {
-      "name": "'lowercase words'",
+      "name": "lowercase words",
       "cmd": "bash acronym.sh 'Ruby on Rails'"
     },
     {
-      "name": "'punctuation'",
+      "name": "punctuation",
       "cmd": "bash acronym.sh 'First In, First Out'"
     },
     {
-      "name": "'all caps word'",
+      "name": "all caps word",
       "cmd": "bash acronym.sh 'GNU Image Manipulation Program'"
     },
     {
-      "name": "'punctuation without whitespace'",
+      "name": "punctuation without whitespace",
       "cmd": "bash acronym.sh 'Complementary metal-oxide semiconductor'"
     },
     {
-      "name": "'very long abbreviation'",
+      "name": "very long abbreviation",
       "cmd": "bash acronym.sh 'Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me'"
     },
     {
-      "name": "\"consecutive delimiters\"",
+      "name": "consecutive delimiters",
       "cmd": "bash acronym.sh \"Something - I made up from thin air\""
     },
     {
-      "name": "\"apostrophes\"",
+      "name": "apostrophes",
       "cmd": "bash acronym.sh \"Halley's Comet\""
     },
     {
-      "name": "\"underscore emphasis\"",
+      "name": "underscore emphasis",
       "cmd": "bash acronym.sh \"The Road __Not__ Taken\""
     },
     {
-      "name": "\"contains shell globbing character\"",
+      "name": "contains shell globbing character",
       "cmd": "bash acronym.sh \"Two * Words\""
     }
   ]

--- a/exercises/acronym/.meta/config.json
+++ b/exercises/acronym/.meta/config.json
@@ -1,0 +1,47 @@
+{
+  "solution_files": [
+    "acronym.sh"
+  ],
+  "tests": [
+    {
+      "name": "'basic'",
+      "cmd": "bash acronym.sh 'Portable Network Graphics'"
+    },
+    {
+      "name": "'lowercase words'",
+      "cmd": "bash acronym.sh 'Ruby on Rails'"
+    },
+    {
+      "name": "'punctuation'",
+      "cmd": "bash acronym.sh 'First In, First Out'"
+    },
+    {
+      "name": "'all caps word'",
+      "cmd": "bash acronym.sh 'GNU Image Manipulation Program'"
+    },
+    {
+      "name": "'punctuation without whitespace'",
+      "cmd": "bash acronym.sh 'Complementary metal-oxide semiconductor'"
+    },
+    {
+      "name": "'very long abbreviation'",
+      "cmd": "bash acronym.sh 'Rolling On The Floor Laughing So Hard That My Dogs Came Over And Licked Me'"
+    },
+    {
+      "name": "\"consecutive delimiters\"",
+      "cmd": "bash acronym.sh \"Something - I made up from thin air\""
+    },
+    {
+      "name": "\"apostrophes\"",
+      "cmd": "bash acronym.sh \"Halley's Comet\""
+    },
+    {
+      "name": "\"underscore emphasis\"",
+      "cmd": "bash acronym.sh \"The Road __Not__ Taken\""
+    },
+    {
+      "name": "\"contains shell globbing character\"",
+      "cmd": "bash acronym.sh \"Two * Words\""
+    }
+  ]
+}

--- a/exercises/affine-cipher/.meta/config.json
+++ b/exercises/affine-cipher/.meta/config.json
@@ -4,67 +4,67 @@
   ],
   "tests": [
     {
-      "name": "\"encode yes\"",
+      "name": "encode yes",
       "cmd": "bash affine_cipher.sh encode 5 7 \"yes\""
     },
     {
-      "name": "\"encode no\"",
+      "name": "encode no",
       "cmd": "bash affine_cipher.sh encode 15 18 \"no\""
     },
     {
-      "name": "\"encode OMG\"",
+      "name": "encode OMG",
       "cmd": "bash affine_cipher.sh encode 21 3 \"OMG\""
     },
     {
-      "name": "\"encode O M G\"",
+      "name": "encode O M G",
       "cmd": "bash affine_cipher.sh encode 25 47 \"O M G\""
     },
     {
-      "name": "\"encode mindblowingly\"",
+      "name": "encode mindblowingly",
       "cmd": "bash affine_cipher.sh encode 11 15 \"mindblowingly\""
     },
     {
-      "name": "\"encode numbers\"",
+      "name": "encode numbers",
       "cmd": "bash affine_cipher.sh encode 3 4 \"Testing,1 2 3, testing.\""
     },
     {
-      "name": "\"encode deep thought\"",
+      "name": "encode deep thought",
       "cmd": "bash affine_cipher.sh encode 5 17 \"Truth is fiction.\""
     },
     {
-      "name": "\"encode all the letters\"",
+      "name": "encode all the letters",
       "cmd": "bash affine_cipher.sh encode 17 33 \"The quick brown fox jumps over the lazy dog.\""
     },
     {
-      "name": "\"encode with a not coprime to m\"",
+      "name": "encode with a not coprime to m",
       "cmd": "bash affine_cipher.sh encode 6 17 \"This is a test.\""
     },
     {
-      "name": "\"decode exercism\"",
+      "name": "decode exercism",
       "cmd": "bash affine_cipher.sh decode 3 7 \"tytgn fjr\""
     },
     {
-      "name": "\"decode a sentence\"",
+      "name": "decode a sentence",
       "cmd": "bash affine_cipher.sh decode 19 16 \"qdwju nqcro muwhn odqun oppmd aunwd o\""
     },
     {
-      "name": "\"decode numbers\"",
+      "name": "decode numbers",
       "cmd": "bash affine_cipher.sh decode 25 7 \"odpoz ub123 odpoz ub\""
     },
     {
-      "name": "\"decode all the letters\"",
+      "name": "decode all the letters",
       "cmd": "bash affine_cipher.sh decode 17 33 \"swxtj npvyk lruol iejdc blaxk swxmh qzglf\""
     },
     {
-      "name": "\"decode with no spaces in input\"",
+      "name": "decode with no spaces in input",
       "cmd": "bash affine_cipher.sh decode 17 33 \"swxtjnpvyklruoliejdcblaxkswxmhqzglf\""
     },
     {
-      "name": "\"decode with too many spaces\"",
+      "name": "decode with too many spaces",
       "cmd": "bash affine_cipher.sh decode 15 16 \"vszzm cly yd cg qdp\""
     },
     {
-      "name": "\"decode with a not coprime to m\"",
+      "name": "decode with a not coprime to m",
       "cmd": "bash affine_cipher.sh decode 13 5 \"Test\""
     }
   ]

--- a/exercises/affine-cipher/.meta/config.json
+++ b/exercises/affine-cipher/.meta/config.json
@@ -1,0 +1,71 @@
+{
+  "solution_files": [
+    "affine_cipher.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"encode yes\"",
+      "cmd": "bash affine_cipher.sh encode 5 7 \"yes\""
+    },
+    {
+      "name": "\"encode no\"",
+      "cmd": "bash affine_cipher.sh encode 15 18 \"no\""
+    },
+    {
+      "name": "\"encode OMG\"",
+      "cmd": "bash affine_cipher.sh encode 21 3 \"OMG\""
+    },
+    {
+      "name": "\"encode O M G\"",
+      "cmd": "bash affine_cipher.sh encode 25 47 \"O M G\""
+    },
+    {
+      "name": "\"encode mindblowingly\"",
+      "cmd": "bash affine_cipher.sh encode 11 15 \"mindblowingly\""
+    },
+    {
+      "name": "\"encode numbers\"",
+      "cmd": "bash affine_cipher.sh encode 3 4 \"Testing,1 2 3, testing.\""
+    },
+    {
+      "name": "\"encode deep thought\"",
+      "cmd": "bash affine_cipher.sh encode 5 17 \"Truth is fiction.\""
+    },
+    {
+      "name": "\"encode all the letters\"",
+      "cmd": "bash affine_cipher.sh encode 17 33 \"The quick brown fox jumps over the lazy dog.\""
+    },
+    {
+      "name": "\"encode with a not coprime to m\"",
+      "cmd": "bash affine_cipher.sh encode 6 17 \"This is a test.\""
+    },
+    {
+      "name": "\"decode exercism\"",
+      "cmd": "bash affine_cipher.sh decode 3 7 \"tytgn fjr\""
+    },
+    {
+      "name": "\"decode a sentence\"",
+      "cmd": "bash affine_cipher.sh decode 19 16 \"qdwju nqcro muwhn odqun oppmd aunwd o\""
+    },
+    {
+      "name": "\"decode numbers\"",
+      "cmd": "bash affine_cipher.sh decode 25 7 \"odpoz ub123 odpoz ub\""
+    },
+    {
+      "name": "\"decode all the letters\"",
+      "cmd": "bash affine_cipher.sh decode 17 33 \"swxtj npvyk lruol iejdc blaxk swxmh qzglf\""
+    },
+    {
+      "name": "\"decode with no spaces in input\"",
+      "cmd": "bash affine_cipher.sh decode 17 33 \"swxtjnpvyklruoliejdcblaxkswxmhqzglf\""
+    },
+    {
+      "name": "\"decode with too many spaces\"",
+      "cmd": "bash affine_cipher.sh decode 15 16 \"vszzm cly yd cg qdp\""
+    },
+    {
+      "name": "\"decode with a not coprime to m\"",
+      "cmd": "bash affine_cipher.sh decode 13 5 \"Test\""
+    }
+  ]
+}

--- a/exercises/all-your-base/.meta/config.json
+++ b/exercises/all-your-base/.meta/config.json
@@ -4,87 +4,87 @@
   ],
   "tests": [
     {
-      "name": "'single bit to one decimal'",
+      "name": "single bit to one decimal",
       "cmd": "bash all_your_base.sh 2 \"1\" 10"
     },
     {
-      "name": "'binary to single decimal'",
+      "name": "binary to single decimal",
       "cmd": "bash all_your_base.sh 2 \"1 0 1\" 10"
     },
     {
-      "name": "'single decimal to binary'",
+      "name": "single decimal to binary",
       "cmd": "bash all_your_base.sh 10 \"5\" 2"
     },
     {
-      "name": "'binary to multiple decimal'",
+      "name": "binary to multiple decimal",
       "cmd": "bash all_your_base.sh 2 \"1 0 1 0 1 0\" 10"
     },
     {
-      "name": "'decimal to binary'",
+      "name": "decimal to binary",
       "cmd": "bash all_your_base.sh 10 \"4 2\" 2"
     },
     {
-      "name": "'trinary to hexadecimal'",
+      "name": "trinary to hexadecimal",
       "cmd": "bash all_your_base.sh 3 \"1 1 2 0\" 16"
     },
     {
-      "name": "'hexadecimal to trinary'",
+      "name": "hexadecimal to trinary",
       "cmd": "bash all_your_base.sh 16 \"2 10\" 3"
     },
     {
-      "name": "'15 bit integer'",
+      "name": "15 bit integer",
       "cmd": "bash all_your_base.sh 97 \"3 46 60\" 73"
     },
     {
-      "name": "'empty list'",
+      "name": "empty list",
       "cmd": "bash all_your_base.sh 2 \"\" 10"
     },
     {
-      "name": "'single zero'",
+      "name": "single zero",
       "cmd": "bash all_your_base.sh 10 \"0\" 2"
     },
     {
-      "name": "'multiple zeroes'",
+      "name": "multiple zeroes",
       "cmd": "bash all_your_base.sh 10 \"0 0 0\" 2"
     },
     {
-      "name": "'leading zeros'",
+      "name": "leading zeros",
       "cmd": "bash all_your_base.sh 7 \"0 6 0\" 10"
     },
     {
-      "name": "'input base is one'",
+      "name": "input base is one",
       "cmd": "bash all_your_base.sh 1 \"0\" 10"
     },
     {
-      "name": "'input base is zero'",
+      "name": "input base is zero",
       "cmd": "bash all_your_base.sh 0 \"\" 10"
     },
     {
-      "name": "'input base is negative'",
+      "name": "input base is negative",
       "cmd": "bash all_your_base.sh -2 \"1\" 10"
     },
     {
-      "name": "'negative digit'",
+      "name": "negative digit",
       "cmd": "bash all_your_base.sh 2 \"1 -1 1 0 1 0\" 10"
     },
     {
-      "name": "'invalid positive digit'",
+      "name": "invalid positive digit",
       "cmd": "bash all_your_base.sh 2 \"1 2 1 0 1 0\" 10"
     },
     {
-      "name": "'output base is one'",
+      "name": "output base is one",
       "cmd": "bash all_your_base.sh 2 \"1 0 1 0 1 0\" 1"
     },
     {
-      "name": "'output base is zero'",
+      "name": "output base is zero",
       "cmd": "bash all_your_base.sh 10 \"7\" 0"
     },
     {
-      "name": "'output base is negative'",
+      "name": "output base is negative",
       "cmd": "bash all_your_base.sh 2 \"1\" -7"
     },
     {
-      "name": "'both bases are negative'",
+      "name": "both bases are negative",
       "cmd": "bash all_your_base.sh -2 \"1\" -7"
     }
   ]

--- a/exercises/all-your-base/.meta/config.json
+++ b/exercises/all-your-base/.meta/config.json
@@ -1,0 +1,91 @@
+{
+  "solution_files": [
+    "all_your_base.sh"
+  ],
+  "tests": [
+    {
+      "name": "'single bit to one decimal'",
+      "cmd": "bash all_your_base.sh 2 \"1\" 10"
+    },
+    {
+      "name": "'binary to single decimal'",
+      "cmd": "bash all_your_base.sh 2 \"1 0 1\" 10"
+    },
+    {
+      "name": "'single decimal to binary'",
+      "cmd": "bash all_your_base.sh 10 \"5\" 2"
+    },
+    {
+      "name": "'binary to multiple decimal'",
+      "cmd": "bash all_your_base.sh 2 \"1 0 1 0 1 0\" 10"
+    },
+    {
+      "name": "'decimal to binary'",
+      "cmd": "bash all_your_base.sh 10 \"4 2\" 2"
+    },
+    {
+      "name": "'trinary to hexadecimal'",
+      "cmd": "bash all_your_base.sh 3 \"1 1 2 0\" 16"
+    },
+    {
+      "name": "'hexadecimal to trinary'",
+      "cmd": "bash all_your_base.sh 16 \"2 10\" 3"
+    },
+    {
+      "name": "'15 bit integer'",
+      "cmd": "bash all_your_base.sh 97 \"3 46 60\" 73"
+    },
+    {
+      "name": "'empty list'",
+      "cmd": "bash all_your_base.sh 2 \"\" 10"
+    },
+    {
+      "name": "'single zero'",
+      "cmd": "bash all_your_base.sh 10 \"0\" 2"
+    },
+    {
+      "name": "'multiple zeroes'",
+      "cmd": "bash all_your_base.sh 10 \"0 0 0\" 2"
+    },
+    {
+      "name": "'leading zeros'",
+      "cmd": "bash all_your_base.sh 7 \"0 6 0\" 10"
+    },
+    {
+      "name": "'input base is one'",
+      "cmd": "bash all_your_base.sh 1 \"0\" 10"
+    },
+    {
+      "name": "'input base is zero'",
+      "cmd": "bash all_your_base.sh 0 \"\" 10"
+    },
+    {
+      "name": "'input base is negative'",
+      "cmd": "bash all_your_base.sh -2 \"1\" 10"
+    },
+    {
+      "name": "'negative digit'",
+      "cmd": "bash all_your_base.sh 2 \"1 -1 1 0 1 0\" 10"
+    },
+    {
+      "name": "'invalid positive digit'",
+      "cmd": "bash all_your_base.sh 2 \"1 2 1 0 1 0\" 10"
+    },
+    {
+      "name": "'output base is one'",
+      "cmd": "bash all_your_base.sh 2 \"1 0 1 0 1 0\" 1"
+    },
+    {
+      "name": "'output base is zero'",
+      "cmd": "bash all_your_base.sh 10 \"7\" 0"
+    },
+    {
+      "name": "'output base is negative'",
+      "cmd": "bash all_your_base.sh 2 \"1\" -7"
+    },
+    {
+      "name": "'both bases are negative'",
+      "cmd": "bash all_your_base.sh -2 \"1\" -7"
+    }
+  ]
+}

--- a/exercises/allergies/.meta/config.json
+++ b/exercises/allergies/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "allergies.sh"
+  ],
+  "tests": [
+    {
+      "name": "no_allergies_means_not_allergic",
+      "cmd": "bash allergies.sh 0 allergic_to peanuts"
+    },
+    {
+      "name": "is_allergic_to_eggs",
+      "cmd": "bash allergies.sh 1 allergic_to eggs"
+    },
+    {
+      "name": "allergic_to_eggs_in_addition_to_other_stuff",
+      "cmd": "bash allergies.sh 5 allergic_to eggs"
+    },
+    {
+      "name": "allergic_to_strawberries_but_not_peanuts",
+      "cmd": "bash allergies.sh 9 allergic_to eggs"
+    },
+    {
+      "name": "no_allergies_at_all",
+      "cmd": "bash allergies.sh 0 list"
+    },
+    {
+      "name": "allergic_to_just_eggs",
+      "cmd": "bash allergies.sh 1 list"
+    },
+    {
+      "name": "allergic_to_just_peanuts",
+      "cmd": "bash allergies.sh 2 list"
+    },
+    {
+      "name": "allergic_to_just_strawberries",
+      "cmd": "bash allergies.sh 8 list"
+    },
+    {
+      "name": "allergic_to_eggs_and_peanuts",
+      "cmd": "bash allergies.sh 3 list"
+    },
+    {
+      "name": "allergic_to_more_than_eggs_but_not_peanuts",
+      "cmd": "bash allergies.sh 5 list"
+    },
+    {
+      "name": "allergic_to_lots_of_stuff",
+      "cmd": "bash allergies.sh 248 list"
+    },
+    {
+      "name": "allergic_to_everything",
+      "cmd": "bash allergies.sh 255 list"
+    },
+    {
+      "name": "ignore_non_allergen_score_parts",
+      "cmd": "bash allergies.sh 509 list"
+    }
+  ]
+}

--- a/exercises/anagram/.meta/config.json
+++ b/exercises/anagram/.meta/config.json
@@ -1,0 +1,63 @@
+{
+  "solution_files": [
+    "anagram.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"no matches\"",
+      "cmd": "bash anagram.sh \"diaper\" \"hello world zombies pants\""
+    },
+    {
+      "name": "\"detects two anagrams\"",
+      "cmd": "bash anagram.sh \"master\" \"stream pigeon maters\""
+    },
+    {
+      "name": "\"does not detect anagram subsets\"",
+      "cmd": "bash anagram.sh \"good\" \"dog goody\""
+    },
+    {
+      "name": "\"detects anagram\"",
+      "cmd": "bash anagram.sh \"listen\" \"enlists google inlets banana\""
+    },
+    {
+      "name": "\"detects three anagrams\"",
+      "cmd": "bash anagram.sh \"allergy\" \"gallery ballerina regally clergy largely leading\""
+    },
+    {
+      "name": "\"detects multiple anagrams with different case\"",
+      "cmd": "bash anagram.sh \"nose\" \"Eons ONES\""
+    },
+    {
+      "name": "\"does not detect non-anagrams with identical checksum\"",
+      "cmd": "bash anagram.sh \"mass\" \"last\""
+    },
+    {
+      "name": "\"detects anagrams case-insensitively\"",
+      "cmd": "bash anagram.sh \"Orchestra\" \"cashregister Carthorse radishes\""
+    },
+    {
+      "name": "\"detects anagrams using case-insensitive subject\"",
+      "cmd": "bash anagram.sh \"Orchestra\" \"cashregister carthorse radishes\""
+    },
+    {
+      "name": "\"detects anagrams using case-insensitive possible matches\"",
+      "cmd": "bash anagram.sh \"orchestra\" \"cashregister Carthorse radishes\""
+    },
+    {
+      "name": "\"does not detect a anagram if the original word is repeated\"",
+      "cmd": "bash anagram.sh \"go\" \"go Go GO\""
+    },
+    {
+      "name": "\"anagrams must use all letters exactly once\"",
+      "cmd": "bash anagram.sh \"tapper\" \"patter\""
+    },
+    {
+      "name": "\"capital word is not own anagram\"",
+      "cmd": "bash anagram.sh \"BANANA\" \"BANANA Banana banana\""
+    },
+    {
+      "name": "\"words other than themselves can be anagrams\"",
+      "cmd": "bash anagram.sh \"LISTEN\" \"Listen Silent LISTEN\""
+    }
+  ]
+}

--- a/exercises/anagram/.meta/config.json
+++ b/exercises/anagram/.meta/config.json
@@ -4,59 +4,59 @@
   ],
   "tests": [
     {
-      "name": "\"no matches\"",
+      "name": "no matches",
       "cmd": "bash anagram.sh \"diaper\" \"hello world zombies pants\""
     },
     {
-      "name": "\"detects two anagrams\"",
+      "name": "detects two anagrams",
       "cmd": "bash anagram.sh \"master\" \"stream pigeon maters\""
     },
     {
-      "name": "\"does not detect anagram subsets\"",
+      "name": "does not detect anagram subsets",
       "cmd": "bash anagram.sh \"good\" \"dog goody\""
     },
     {
-      "name": "\"detects anagram\"",
+      "name": "detects anagram",
       "cmd": "bash anagram.sh \"listen\" \"enlists google inlets banana\""
     },
     {
-      "name": "\"detects three anagrams\"",
+      "name": "detects three anagrams",
       "cmd": "bash anagram.sh \"allergy\" \"gallery ballerina regally clergy largely leading\""
     },
     {
-      "name": "\"detects multiple anagrams with different case\"",
+      "name": "detects multiple anagrams with different case",
       "cmd": "bash anagram.sh \"nose\" \"Eons ONES\""
     },
     {
-      "name": "\"does not detect non-anagrams with identical checksum\"",
+      "name": "does not detect non-anagrams with identical checksum",
       "cmd": "bash anagram.sh \"mass\" \"last\""
     },
     {
-      "name": "\"detects anagrams case-insensitively\"",
+      "name": "detects anagrams case-insensitively",
       "cmd": "bash anagram.sh \"Orchestra\" \"cashregister Carthorse radishes\""
     },
     {
-      "name": "\"detects anagrams using case-insensitive subject\"",
+      "name": "detects anagrams using case-insensitive subject",
       "cmd": "bash anagram.sh \"Orchestra\" \"cashregister carthorse radishes\""
     },
     {
-      "name": "\"detects anagrams using case-insensitive possible matches\"",
+      "name": "detects anagrams using case-insensitive possible matches",
       "cmd": "bash anagram.sh \"orchestra\" \"cashregister Carthorse radishes\""
     },
     {
-      "name": "\"does not detect a anagram if the original word is repeated\"",
+      "name": "does not detect a anagram if the original word is repeated",
       "cmd": "bash anagram.sh \"go\" \"go Go GO\""
     },
     {
-      "name": "\"anagrams must use all letters exactly once\"",
+      "name": "anagrams must use all letters exactly once",
       "cmd": "bash anagram.sh \"tapper\" \"patter\""
     },
     {
-      "name": "\"capital word is not own anagram\"",
+      "name": "capital word is not own anagram",
       "cmd": "bash anagram.sh \"BANANA\" \"BANANA Banana banana\""
     },
     {
-      "name": "\"words other than themselves can be anagrams\"",
+      "name": "words other than themselves can be anagrams",
       "cmd": "bash anagram.sh \"LISTEN\" \"Listen Silent LISTEN\""
     }
   ]

--- a/exercises/armstrong-numbers/.meta/config.json
+++ b/exercises/armstrong-numbers/.meta/config.json
@@ -1,0 +1,43 @@
+{
+  "solution_files": [
+    "armstrong_numbers.sh"
+  ],
+  "tests": [
+    {
+      "name": "'Zero is Armstrong numbers'",
+      "cmd": "bash armstrong_numbers.sh 0"
+    },
+    {
+      "name": "'Single digits are Armstrong numbers'",
+      "cmd": "bash armstrong_numbers.sh 5"
+    },
+    {
+      "name": "'There are no two digit Armstrong numbers'",
+      "cmd": "bash armstrong_numbers.sh 10"
+    },
+    {
+      "name": "'A three digit number that is an Armstrong number'",
+      "cmd": "bash armstrong_numbers.sh 153"
+    },
+    {
+      "name": "'A three digit number that is not an Armstrong number'",
+      "cmd": "bash armstrong_numbers.sh 100"
+    },
+    {
+      "name": "'A four digit number that is an Armstrong number'",
+      "cmd": "bash armstrong_numbers.sh 9474"
+    },
+    {
+      "name": "'A four digit number that is not an Armstrong number'",
+      "cmd": "bash armstrong_numbers.sh 9475"
+    },
+    {
+      "name": "'A seven digit number that is an Armstrong number'",
+      "cmd": "bash armstrong_numbers.sh 9926315"
+    },
+    {
+      "name": "'A seven digit number that is not an Armstrong number'",
+      "cmd": "bash armstrong_numbers.sh 9926314"
+    }
+  ]
+}

--- a/exercises/armstrong-numbers/.meta/config.json
+++ b/exercises/armstrong-numbers/.meta/config.json
@@ -4,39 +4,39 @@
   ],
   "tests": [
     {
-      "name": "'Zero is Armstrong numbers'",
+      "name": "Zero is Armstrong numbers",
       "cmd": "bash armstrong_numbers.sh 0"
     },
     {
-      "name": "'Single digits are Armstrong numbers'",
+      "name": "Single digits are Armstrong numbers",
       "cmd": "bash armstrong_numbers.sh 5"
     },
     {
-      "name": "'There are no two digit Armstrong numbers'",
+      "name": "There are no two digit Armstrong numbers",
       "cmd": "bash armstrong_numbers.sh 10"
     },
     {
-      "name": "'A three digit number that is an Armstrong number'",
+      "name": "A three digit number that is an Armstrong number",
       "cmd": "bash armstrong_numbers.sh 153"
     },
     {
-      "name": "'A three digit number that is not an Armstrong number'",
+      "name": "A three digit number that is not an Armstrong number",
       "cmd": "bash armstrong_numbers.sh 100"
     },
     {
-      "name": "'A four digit number that is an Armstrong number'",
+      "name": "A four digit number that is an Armstrong number",
       "cmd": "bash armstrong_numbers.sh 9474"
     },
     {
-      "name": "'A four digit number that is not an Armstrong number'",
+      "name": "A four digit number that is not an Armstrong number",
       "cmd": "bash armstrong_numbers.sh 9475"
     },
     {
-      "name": "'A seven digit number that is an Armstrong number'",
+      "name": "A seven digit number that is an Armstrong number",
       "cmd": "bash armstrong_numbers.sh 9926315"
     },
     {
-      "name": "'A seven digit number that is not an Armstrong number'",
+      "name": "A seven digit number that is not an Armstrong number",
       "cmd": "bash armstrong_numbers.sh 9926314"
     }
   ]

--- a/exercises/atbash-cipher/.meta/config.json
+++ b/exercises/atbash-cipher/.meta/config.json
@@ -1,0 +1,63 @@
+{
+  "solution_files": [
+    "atbash_cipher.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"encode yes\"",
+      "cmd": "bash atbash_cipher.sh encode \"yes\""
+    },
+    {
+      "name": "\"encode no\"",
+      "cmd": "bash atbash_cipher.sh encode \"no\""
+    },
+    {
+      "name": "\"encode OMG\"",
+      "cmd": "bash atbash_cipher.sh encode \"OMG\""
+    },
+    {
+      "name": "\"encode spaces\"",
+      "cmd": "bash atbash_cipher.sh encode \"O M G\""
+    },
+    {
+      "name": "\"encode mindblowingly\"",
+      "cmd": "bash atbash_cipher.sh encode \"mindblowingly\""
+    },
+    {
+      "name": "\"encode numbers\"",
+      "cmd": "bash atbash_cipher.sh encode \"Testing,1 2 3, testing.\""
+    },
+    {
+      "name": "\"encode deep thought\"",
+      "cmd": "bash atbash_cipher.sh encode \"Truth is fiction.\""
+    },
+    {
+      "name": "\"encode all the letters\"",
+      "cmd": "bash atbash_cipher.sh encode \"The quick brown fox jumps over the lazy dog.\""
+    },
+    {
+      "name": "\"decode exercism\"",
+      "cmd": "bash atbash_cipher.sh decode \"vcvix rhn\""
+    },
+    {
+      "name": "\"decode a sentence\"",
+      "cmd": "bash atbash_cipher.sh decode \"zmlyh gzxov rhlug vmzhg vkkrm thglm v\""
+    },
+    {
+      "name": "\"decode numbers\"",
+      "cmd": "bash atbash_cipher.sh decode \"gvhgr mt123 gvhgr mt\""
+    },
+    {
+      "name": "\"decode all the letters\"",
+      "cmd": "bash atbash_cipher.sh decode \"gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt\""
+    },
+    {
+      "name": "\"decode with too many spaces\"",
+      "cmd": "bash atbash_cipher.sh decode \"vc vix r hn\""
+    },
+    {
+      "name": "\"decode with no spaces\"",
+      "cmd": "bash atbash_cipher.sh decode \"zmlyhgzxovrhlugvmzhgvkkrmthglmv\""
+    }
+  ]
+}

--- a/exercises/atbash-cipher/.meta/config.json
+++ b/exercises/atbash-cipher/.meta/config.json
@@ -4,59 +4,59 @@
   ],
   "tests": [
     {
-      "name": "\"encode yes\"",
+      "name": "encode yes",
       "cmd": "bash atbash_cipher.sh encode \"yes\""
     },
     {
-      "name": "\"encode no\"",
+      "name": "encode no",
       "cmd": "bash atbash_cipher.sh encode \"no\""
     },
     {
-      "name": "\"encode OMG\"",
+      "name": "encode OMG",
       "cmd": "bash atbash_cipher.sh encode \"OMG\""
     },
     {
-      "name": "\"encode spaces\"",
+      "name": "encode spaces",
       "cmd": "bash atbash_cipher.sh encode \"O M G\""
     },
     {
-      "name": "\"encode mindblowingly\"",
+      "name": "encode mindblowingly",
       "cmd": "bash atbash_cipher.sh encode \"mindblowingly\""
     },
     {
-      "name": "\"encode numbers\"",
+      "name": "encode numbers",
       "cmd": "bash atbash_cipher.sh encode \"Testing,1 2 3, testing.\""
     },
     {
-      "name": "\"encode deep thought\"",
+      "name": "encode deep thought",
       "cmd": "bash atbash_cipher.sh encode \"Truth is fiction.\""
     },
     {
-      "name": "\"encode all the letters\"",
+      "name": "encode all the letters",
       "cmd": "bash atbash_cipher.sh encode \"The quick brown fox jumps over the lazy dog.\""
     },
     {
-      "name": "\"decode exercism\"",
+      "name": "decode exercism",
       "cmd": "bash atbash_cipher.sh decode \"vcvix rhn\""
     },
     {
-      "name": "\"decode a sentence\"",
+      "name": "decode a sentence",
       "cmd": "bash atbash_cipher.sh decode \"zmlyh gzxov rhlug vmzhg vkkrm thglm v\""
     },
     {
-      "name": "\"decode numbers\"",
+      "name": "decode numbers",
       "cmd": "bash atbash_cipher.sh decode \"gvhgr mt123 gvhgr mt\""
     },
     {
-      "name": "\"decode all the letters\"",
+      "name": "decode all the letters",
       "cmd": "bash atbash_cipher.sh decode \"gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt\""
     },
     {
-      "name": "\"decode with too many spaces\"",
+      "name": "decode with too many spaces",
       "cmd": "bash atbash_cipher.sh decode \"vc vix r hn\""
     },
     {
-      "name": "\"decode with no spaces\"",
+      "name": "decode with no spaces",
       "cmd": "bash atbash_cipher.sh decode \"zmlyhgzxovrhlugvmzhgvkkrmthglmv\""
     }
   ]

--- a/exercises/beer-song/.meta/config.json
+++ b/exercises/beer-song/.meta/config.json
@@ -4,47 +4,47 @@
   ],
   "tests": [
     {
-      "name": "'first_generic_verse'",
+      "name": "first_generic_verse",
       "cmd": "bash beer_song.sh 99"
     },
     {
-      "name": "'3rd_last_generic_verse'",
+      "name": "3rd_last_generic_verse",
       "cmd": "bash beer_song.sh 3"
     },
     {
-      "name": "'2nd_last_generic_verse'",
+      "name": "2nd_last_generic_verse",
       "cmd": "bash beer_song.sh 2"
     },
     {
-      "name": "'penultimate_verse'",
+      "name": "penultimate_verse",
       "cmd": "bash beer_song.sh 1"
     },
     {
-      "name": "'verse_with_zero_bottles'",
+      "name": "verse_with_zero_bottles",
       "cmd": "bash beer_song.sh 0"
     },
     {
-      "name": "'first_two_verses'",
+      "name": "first_two_verses",
       "cmd": "bash beer_song.sh 99 98"
     },
     {
-      "name": "'last_three_verses'",
+      "name": "last_three_verses",
       "cmd": "bash beer_song.sh 2 0"
     },
     {
-      "name": "'all_verses'",
+      "name": "all_verses",
       "cmd": "bash beer_song.sh 99 0"
     },
     {
-      "name": "'no_arguments'",
+      "name": "no_arguments",
       "cmd": "bash beer_song.sh"
     },
     {
-      "name": "'too_many_arguments'",
+      "name": "too_many_arguments",
       "cmd": "bash beer_song.sh 1 2 3"
     },
     {
-      "name": "'wrong_order_arguments'",
+      "name": "wrong_order_arguments",
       "cmd": "bash beer_song.sh 1 2"
     }
   ]

--- a/exercises/beer-song/.meta/config.json
+++ b/exercises/beer-song/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "beer_song.sh"
+  ],
+  "tests": [
+    {
+      "name": "'first_generic_verse'",
+      "cmd": "bash beer_song.sh 99"
+    },
+    {
+      "name": "'3rd_last_generic_verse'",
+      "cmd": "bash beer_song.sh 3"
+    },
+    {
+      "name": "'2nd_last_generic_verse'",
+      "cmd": "bash beer_song.sh 2"
+    },
+    {
+      "name": "'penultimate_verse'",
+      "cmd": "bash beer_song.sh 1"
+    },
+    {
+      "name": "'verse_with_zero_bottles'",
+      "cmd": "bash beer_song.sh 0"
+    },
+    {
+      "name": "'first_two_verses'",
+      "cmd": "bash beer_song.sh 99 98"
+    },
+    {
+      "name": "'last_three_verses'",
+      "cmd": "bash beer_song.sh 2 0"
+    },
+    {
+      "name": "'all_verses'",
+      "cmd": "bash beer_song.sh 99 0"
+    },
+    {
+      "name": "'no_arguments'",
+      "cmd": "bash beer_song.sh"
+    },
+    {
+      "name": "'too_many_arguments'",
+      "cmd": "bash beer_song.sh 1 2 3"
+    },
+    {
+      "name": "'wrong_order_arguments'",
+      "cmd": "bash beer_song.sh 1 2"
+    }
+  ]
+}

--- a/exercises/binary-search/.meta/config.json
+++ b/exercises/binary-search/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "binary_search.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"finds a value in an array with one element\"",
+      "cmd": "bash binary_search.sh 6 \"${input[@]}\""
+    },
+    {
+      "name": "\"finds a value in the middle of an array\"",
+      "cmd": "bash binary_search.sh 6 \"${input[@]}\""
+    },
+    {
+      "name": "\"finds a value at the beginning of an array\"",
+      "cmd": "bash binary_search.sh 1 \"${input[@]}\""
+    },
+    {
+      "name": "\"finds a value at the end of an array\"",
+      "cmd": "bash binary_search.sh 11 \"${input[@]}\""
+    },
+    {
+      "name": "\"finds a value in an array of odd length\"",
+      "cmd": "bash binary_search.sh 144 \"${input[@]}\""
+    },
+    {
+      "name": "\"finds a value in an array of even length\"",
+      "cmd": "bash binary_search.sh 21 \"${input[@]}\""
+    },
+    {
+      "name": "\"identifies that a value is not included in the array\"",
+      "cmd": "bash binary_search.sh 7 \"${input[@]}\""
+    },
+    {
+      "name": "\"a value smaller than the array's smallest value is not found\"",
+      "cmd": "bash binary_search.sh 0 \"${input[@]}\""
+    },
+    {
+      "name": "\"a value larger than the array's largest value is not found\"",
+      "cmd": "bash binary_search.sh 13 \"${input[@]}\""
+    },
+    {
+      "name": "\"nothing is found in an empty array\"",
+      "cmd": "bash binary_search.sh 1 \"${input[@]}\""
+    },
+    {
+      "name": "\"nothing is found when the left and right bounds cross\"",
+      "cmd": "bash binary_search.sh 0 \"${input[@]}\""
+    }
+  ]
+}

--- a/exercises/binary-search/.meta/config.json
+++ b/exercises/binary-search/.meta/config.json
@@ -4,47 +4,47 @@
   ],
   "tests": [
     {
-      "name": "\"finds a value in an array with one element\"",
+      "name": "finds a value in an array with one element",
       "cmd": "bash binary_search.sh 6 \"${input[@]}\""
     },
     {
-      "name": "\"finds a value in the middle of an array\"",
+      "name": "finds a value in the middle of an array",
       "cmd": "bash binary_search.sh 6 \"${input[@]}\""
     },
     {
-      "name": "\"finds a value at the beginning of an array\"",
+      "name": "finds a value at the beginning of an array",
       "cmd": "bash binary_search.sh 1 \"${input[@]}\""
     },
     {
-      "name": "\"finds a value at the end of an array\"",
+      "name": "finds a value at the end of an array",
       "cmd": "bash binary_search.sh 11 \"${input[@]}\""
     },
     {
-      "name": "\"finds a value in an array of odd length\"",
+      "name": "finds a value in an array of odd length",
       "cmd": "bash binary_search.sh 144 \"${input[@]}\""
     },
     {
-      "name": "\"finds a value in an array of even length\"",
+      "name": "finds a value in an array of even length",
       "cmd": "bash binary_search.sh 21 \"${input[@]}\""
     },
     {
-      "name": "\"identifies that a value is not included in the array\"",
+      "name": "identifies that a value is not included in the array",
       "cmd": "bash binary_search.sh 7 \"${input[@]}\""
     },
     {
-      "name": "\"a value smaller than the array's smallest value is not found\"",
+      "name": "a value smaller than the array's smallest value is not found",
       "cmd": "bash binary_search.sh 0 \"${input[@]}\""
     },
     {
-      "name": "\"a value larger than the array's largest value is not found\"",
+      "name": "a value larger than the array's largest value is not found",
       "cmd": "bash binary_search.sh 13 \"${input[@]}\""
     },
     {
-      "name": "\"nothing is found in an empty array\"",
+      "name": "nothing is found in an empty array",
       "cmd": "bash binary_search.sh 1 \"${input[@]}\""
     },
     {
-      "name": "\"nothing is found when the left and right bounds cross\"",
+      "name": "nothing is found when the left and right bounds cross",
       "cmd": "bash binary_search.sh 0 \"${input[@]}\""
     }
   ]

--- a/exercises/bob/.meta/config.json
+++ b/exercises/bob/.meta/config.json
@@ -1,0 +1,111 @@
+{
+  "solution_files": [
+    "bob.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"stating something\"",
+      "cmd": "bash bob.sh 'Tom-ay-to, tom-aaaah-to.'"
+    },
+    {
+      "name": "\"shouting\"",
+      "cmd": "bash bob.sh 'WATCH OUT!'"
+    },
+    {
+      "name": "\"shouting gibberish\"",
+      "cmd": "bash bob.sh 'FCECDFCAAB'"
+    },
+    {
+      "name": "\"asking a question\"",
+      "cmd": "bash bob.sh 'Does this cryogenic chamber make me look fat?'"
+    },
+    {
+      "name": "\"asking a numeric question\"",
+      "cmd": "bash bob.sh 'You are, what, like 15?'"
+    },
+    {
+      "name": "\"asking gibberish\"",
+      "cmd": "bash bob.sh 'fffbbcbeab?'"
+    },
+    {
+      "name": "\"talking forcefully\"",
+      "cmd": "bash bob.sh \"Let's go make out behind the gym!\""
+    },
+    {
+      "name": "\"using acronyms in regular speech\"",
+      "cmd": "bash bob.sh \"It's OK if you don't want to go to the DMV.\""
+    },
+    {
+      "name": "\"forceful question\"",
+      "cmd": "bash bob.sh 'WHAT THE HELL WERE YOU THINKING?'"
+    },
+    {
+      "name": "\"shouting numbers\"",
+      "cmd": "bash bob.sh '1, 2, 3 GO!'"
+    },
+    {
+      "name": "\"no letters\"",
+      "cmd": "bash bob.sh '1, 2, 3'"
+    },
+    {
+      "name": "\"question with no letters\"",
+      "cmd": "bash bob.sh '4?'"
+    },
+    {
+      "name": "\"shouting with special characters\"",
+      "cmd": "bash bob.sh 'ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!'"
+    },
+    {
+      "name": "\"shouting with no exclamation mark\"",
+      "cmd": "bash bob.sh 'I HATE THE DMV'"
+    },
+    {
+      "name": "\"statement containing question mark\"",
+      "cmd": "bash bob.sh 'Ending with ? means a question.'"
+    },
+    {
+      "name": "\"non-letters with question\"",
+      "cmd": "bash bob.sh ':) ?'"
+    },
+    {
+      "name": "\"prattling on\"",
+      "cmd": "bash bob.sh 'Wait! Hang on. Are you going to be OK?'"
+    },
+    {
+      "name": "\"silence\"",
+      "cmd": "bash bob.sh ''"
+    },
+    {
+      "name": "\"prolonged silence\"",
+      "cmd": "bash bob.sh ' '"
+    },
+    {
+      "name": "\"alternate silence\"",
+      "cmd": "bash bob.sh $'\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t'"
+    },
+    {
+      "name": "\"multiple line question\"",
+      "cmd": "bash bob.sh $'\\nDoes this cryogenic chamber make me look fat?\\nNo'"
+    },
+    {
+      "name": "\"starting with whitespace\"",
+      "cmd": "bash bob.sh ' hmmmmmmm...'"
+    },
+    {
+      "name": "\"ending with whitespace\"",
+      "cmd": "bash bob.sh 'Okay if like my spacebar quite a bit? '"
+    },
+    {
+      "name": "\"other whitespace\"",
+      "cmd": "bash bob.sh $'\\n\\r \\t'"
+    },
+    {
+      "name": "\"non-question ending with whitespace\"",
+      "cmd": "bash bob.sh 'This is a statement ending with whitespace '"
+    },
+    {
+      "name": "\"no input is silence\"",
+      "cmd": "bash bob.sh"
+    }
+  ]
+}

--- a/exercises/bob/.meta/config.json
+++ b/exercises/bob/.meta/config.json
@@ -4,107 +4,107 @@
   ],
   "tests": [
     {
-      "name": "\"stating something\"",
+      "name": "stating something",
       "cmd": "bash bob.sh 'Tom-ay-to, tom-aaaah-to.'"
     },
     {
-      "name": "\"shouting\"",
+      "name": "shouting",
       "cmd": "bash bob.sh 'WATCH OUT!'"
     },
     {
-      "name": "\"shouting gibberish\"",
+      "name": "shouting gibberish",
       "cmd": "bash bob.sh 'FCECDFCAAB'"
     },
     {
-      "name": "\"asking a question\"",
+      "name": "asking a question",
       "cmd": "bash bob.sh 'Does this cryogenic chamber make me look fat?'"
     },
     {
-      "name": "\"asking a numeric question\"",
+      "name": "asking a numeric question",
       "cmd": "bash bob.sh 'You are, what, like 15?'"
     },
     {
-      "name": "\"asking gibberish\"",
+      "name": "asking gibberish",
       "cmd": "bash bob.sh 'fffbbcbeab?'"
     },
     {
-      "name": "\"talking forcefully\"",
+      "name": "talking forcefully",
       "cmd": "bash bob.sh \"Let's go make out behind the gym!\""
     },
     {
-      "name": "\"using acronyms in regular speech\"",
+      "name": "using acronyms in regular speech",
       "cmd": "bash bob.sh \"It's OK if you don't want to go to the DMV.\""
     },
     {
-      "name": "\"forceful question\"",
+      "name": "forceful question",
       "cmd": "bash bob.sh 'WHAT THE HELL WERE YOU THINKING?'"
     },
     {
-      "name": "\"shouting numbers\"",
+      "name": "shouting numbers",
       "cmd": "bash bob.sh '1, 2, 3 GO!'"
     },
     {
-      "name": "\"no letters\"",
+      "name": "no letters",
       "cmd": "bash bob.sh '1, 2, 3'"
     },
     {
-      "name": "\"question with no letters\"",
+      "name": "question with no letters",
       "cmd": "bash bob.sh '4?'"
     },
     {
-      "name": "\"shouting with special characters\"",
+      "name": "shouting with special characters",
       "cmd": "bash bob.sh 'ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!'"
     },
     {
-      "name": "\"shouting with no exclamation mark\"",
+      "name": "shouting with no exclamation mark",
       "cmd": "bash bob.sh 'I HATE THE DMV'"
     },
     {
-      "name": "\"statement containing question mark\"",
+      "name": "statement containing question mark",
       "cmd": "bash bob.sh 'Ending with ? means a question.'"
     },
     {
-      "name": "\"non-letters with question\"",
+      "name": "non-letters with question",
       "cmd": "bash bob.sh ':) ?'"
     },
     {
-      "name": "\"prattling on\"",
+      "name": "prattling on",
       "cmd": "bash bob.sh 'Wait! Hang on. Are you going to be OK?'"
     },
     {
-      "name": "\"silence\"",
+      "name": "silence",
       "cmd": "bash bob.sh ''"
     },
     {
-      "name": "\"prolonged silence\"",
+      "name": "prolonged silence",
       "cmd": "bash bob.sh ' '"
     },
     {
-      "name": "\"alternate silence\"",
+      "name": "alternate silence",
       "cmd": "bash bob.sh $'\\t\\t\\t\\t\\t\\t\\t\\t\\t\\t'"
     },
     {
-      "name": "\"multiple line question\"",
+      "name": "multiple line question",
       "cmd": "bash bob.sh $'\\nDoes this cryogenic chamber make me look fat?\\nNo'"
     },
     {
-      "name": "\"starting with whitespace\"",
+      "name": "starting with whitespace",
       "cmd": "bash bob.sh ' hmmmmmmm...'"
     },
     {
-      "name": "\"ending with whitespace\"",
+      "name": "ending with whitespace",
       "cmd": "bash bob.sh 'Okay if like my spacebar quite a bit? '"
     },
     {
-      "name": "\"other whitespace\"",
+      "name": "other whitespace",
       "cmd": "bash bob.sh $'\\n\\r \\t'"
     },
     {
-      "name": "\"non-question ending with whitespace\"",
+      "name": "non-question ending with whitespace",
       "cmd": "bash bob.sh 'This is a statement ending with whitespace '"
     },
     {
-      "name": "\"no input is silence\"",
+      "name": "no input is silence",
       "cmd": "bash bob.sh"
     }
   ]

--- a/exercises/bowling/.meta/config.json
+++ b/exercises/bowling/.meta/config.json
@@ -1,0 +1,127 @@
+{
+  "solution_files": [
+    "bowling.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"should be able to score a game with all zeros\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"should be able to score a game with no strikes or spares\"",
+      "cmd": "bash bowling.sh 3 6 3 6 3 6 3 6 3 6 3 6 3 6 3 6 3 6 3 6"
+    },
+    {
+      "name": "\"a spare followed by zeros is worth ten points\"",
+      "cmd": "bash bowling.sh 6 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"points scored in the roll after a spare are counted twice\"",
+      "cmd": "bash bowling.sh 6 4 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"consecutive spares each get a one roll bonus\"",
+      "cmd": "bash bowling.sh 5 5 3 7 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"a spare in the last frame gets a one roll bonus that is counted once\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3 7"
+    },
+    {
+      "name": "\"a strike earns ten points in a frame with a single roll\"",
+      "cmd": "bash bowling.sh 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"points scored in the two rolls after a strike are counted twice as a bonus\"",
+      "cmd": "bash bowling.sh 10 5 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"consecutive strikes each get the two roll bonus\"",
+      "cmd": "bash bowling.sh 10 10 10 5 3 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"a strike in the last frame gets a two roll bonus that is counted once\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 7 1"
+    },
+    {
+      "name": "\"rolling a spare with the two roll bonus does not get a bonus roll\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 7 3"
+    },
+    {
+      "name": "\"strikes with the two roll bonus do not get bonus rolls\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10 10"
+    },
+    {
+      "name": "\"a strike with the one roll bonus after a spare in the last frame does not get a bonus\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3 10"
+    },
+    {
+      "name": "\"all strikes is a perfect game\"",
+      "cmd": "bash bowling.sh 10 10 10 10 10 10 10 10 10 10 10 10"
+    },
+    {
+      "name": "\"rolls cannot score negative points\"",
+      "cmd": "bash bowling.sh -1"
+    },
+    {
+      "name": "\"a roll cannot score more than 10 points\"",
+      "cmd": "bash bowling.sh 11"
+    },
+    {
+      "name": "\"two rolls in a frame cannot score more than 10 points\"",
+      "cmd": "bash bowling.sh 5 6"
+    },
+    {
+      "name": "\"bonus roll after a strike in the last frame cannot score more than 10 points\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 11"
+    },
+    {
+      "name": "\"two bonus rolls after a strike in the last frame cannot score more than 10 points\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 5 6"
+    },
+    {
+      "name": "\"two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10 6"
+    },
+    {
+      "name": "\"the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 6 10"
+    },
+    {
+      "name": "\"second bonus roll after a strike in the last frame cannot score more than 10 points\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10 11"
+    },
+    {
+      "name": "\"an unstarted game cannot be scored\"",
+      "cmd": "bash bowling.sh"
+    },
+    {
+      "name": "\"an incomplete game cannot be scored\"",
+      "cmd": "bash bowling.sh 0 0"
+    },
+    {
+      "name": "\"cannot roll if game already has ten frames\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
+    },
+    {
+      "name": "\"bonus rolls for a strike in the last frame must be rolled before score can be calculated\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10"
+    },
+    {
+      "name": "\"both bonus rolls for a strike in the last frame must be rolled before score can be calculated\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10"
+    },
+    {
+      "name": "\"bonus roll for a spare in the last frame must be rolled before score can be calculated\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3"
+    },
+    {
+      "name": "\"cannot roll after bonus roll for spare\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3 2 2"
+    },
+    {
+      "name": "\"cannot roll after bonus rolls for strike\"",
+      "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 3 2 2"
+    }
+  ]
+}

--- a/exercises/bowling/.meta/config.json
+++ b/exercises/bowling/.meta/config.json
@@ -4,123 +4,123 @@
   ],
   "tests": [
     {
-      "name": "\"should be able to score a game with all zeros\"",
+      "name": "should be able to score a game with all zeros",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"should be able to score a game with no strikes or spares\"",
+      "name": "should be able to score a game with no strikes or spares",
       "cmd": "bash bowling.sh 3 6 3 6 3 6 3 6 3 6 3 6 3 6 3 6 3 6 3 6"
     },
     {
-      "name": "\"a spare followed by zeros is worth ten points\"",
+      "name": "a spare followed by zeros is worth ten points",
       "cmd": "bash bowling.sh 6 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"points scored in the roll after a spare are counted twice\"",
+      "name": "points scored in the roll after a spare are counted twice",
       "cmd": "bash bowling.sh 6 4 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"consecutive spares each get a one roll bonus\"",
+      "name": "consecutive spares each get a one roll bonus",
       "cmd": "bash bowling.sh 5 5 3 7 4 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"a spare in the last frame gets a one roll bonus that is counted once\"",
+      "name": "a spare in the last frame gets a one roll bonus that is counted once",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3 7"
     },
     {
-      "name": "\"a strike earns ten points in a frame with a single roll\"",
+      "name": "a strike earns ten points in a frame with a single roll",
       "cmd": "bash bowling.sh 10 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"points scored in the two rolls after a strike are counted twice as a bonus\"",
+      "name": "points scored in the two rolls after a strike are counted twice as a bonus",
       "cmd": "bash bowling.sh 10 5 3 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"consecutive strikes each get the two roll bonus\"",
+      "name": "consecutive strikes each get the two roll bonus",
       "cmd": "bash bowling.sh 10 10 10 5 3 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"a strike in the last frame gets a two roll bonus that is counted once\"",
+      "name": "a strike in the last frame gets a two roll bonus that is counted once",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 7 1"
     },
     {
-      "name": "\"rolling a spare with the two roll bonus does not get a bonus roll\"",
+      "name": "rolling a spare with the two roll bonus does not get a bonus roll",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 7 3"
     },
     {
-      "name": "\"strikes with the two roll bonus do not get bonus rolls\"",
+      "name": "strikes with the two roll bonus do not get bonus rolls",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10 10"
     },
     {
-      "name": "\"a strike with the one roll bonus after a spare in the last frame does not get a bonus\"",
+      "name": "a strike with the one roll bonus after a spare in the last frame does not get a bonus",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3 10"
     },
     {
-      "name": "\"all strikes is a perfect game\"",
+      "name": "all strikes is a perfect game",
       "cmd": "bash bowling.sh 10 10 10 10 10 10 10 10 10 10 10 10"
     },
     {
-      "name": "\"rolls cannot score negative points\"",
+      "name": "rolls cannot score negative points",
       "cmd": "bash bowling.sh -1"
     },
     {
-      "name": "\"a roll cannot score more than 10 points\"",
+      "name": "a roll cannot score more than 10 points",
       "cmd": "bash bowling.sh 11"
     },
     {
-      "name": "\"two rolls in a frame cannot score more than 10 points\"",
+      "name": "two rolls in a frame cannot score more than 10 points",
       "cmd": "bash bowling.sh 5 6"
     },
     {
-      "name": "\"bonus roll after a strike in the last frame cannot score more than 10 points\"",
+      "name": "bonus roll after a strike in the last frame cannot score more than 10 points",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 11"
     },
     {
-      "name": "\"two bonus rolls after a strike in the last frame cannot score more than 10 points\"",
+      "name": "two bonus rolls after a strike in the last frame cannot score more than 10 points",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 5 6"
     },
     {
-      "name": "\"two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike\"",
+      "name": "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10 6"
     },
     {
-      "name": "\"the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike\"",
+      "name": "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 6 10"
     },
     {
-      "name": "\"second bonus roll after a strike in the last frame cannot score more than 10 points\"",
+      "name": "second bonus roll after a strike in the last frame cannot score more than 10 points",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10 11"
     },
     {
-      "name": "\"an unstarted game cannot be scored\"",
+      "name": "an unstarted game cannot be scored",
       "cmd": "bash bowling.sh"
     },
     {
-      "name": "\"an incomplete game cannot be scored\"",
+      "name": "an incomplete game cannot be scored",
       "cmd": "bash bowling.sh 0 0"
     },
     {
-      "name": "\"cannot roll if game already has ten frames\"",
+      "name": "cannot roll if game already has ten frames",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0"
     },
     {
-      "name": "\"bonus rolls for a strike in the last frame must be rolled before score can be calculated\"",
+      "name": "bonus rolls for a strike in the last frame must be rolled before score can be calculated",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10"
     },
     {
-      "name": "\"both bonus rolls for a strike in the last frame must be rolled before score can be calculated\"",
+      "name": "both bonus rolls for a strike in the last frame must be rolled before score can be calculated",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 10"
     },
     {
-      "name": "\"bonus roll for a spare in the last frame must be rolled before score can be calculated\"",
+      "name": "bonus roll for a spare in the last frame must be rolled before score can be calculated",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3"
     },
     {
-      "name": "\"cannot roll after bonus roll for spare\"",
+      "name": "cannot roll after bonus roll for spare",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 7 3 2 2"
     },
     {
-      "name": "\"cannot roll after bonus rolls for strike\"",
+      "name": "cannot roll after bonus rolls for strike",
       "cmd": "bash bowling.sh 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 10 3 2 2"
     }
   ]

--- a/exercises/change/.meta/config.json
+++ b/exercises/change/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "change.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"single coin change\"",
+      "cmd": "bash change.sh 25 \"${coins[@]}\""
+    },
+    {
+      "name": "\"multiple coin change\"",
+      "cmd": "bash change.sh 15 \"${coins[@]}\""
+    },
+    {
+      "name": "\"change with Lilliputian Coins\"",
+      "cmd": "bash change.sh 23 \"${coins[@]}\""
+    },
+    {
+      "name": "\"change with Lower Elbonia Coins\"",
+      "cmd": "bash change.sh 63 \"${coins[@]}\""
+    },
+    {
+      "name": "\"large target values\"",
+      "cmd": "bash change.sh 999 \"${coins[@]}\""
+    },
+    {
+      "name": "\"possible change without unit coins available\"",
+      "cmd": "bash change.sh 21 \"${coins[@]}\""
+    },
+    {
+      "name": "\"another possible change without unit coins available\"",
+      "cmd": "bash change.sh 27 \"${coins[@]}\""
+    },
+    {
+      "name": "\"no coins make 0 change\"",
+      "cmd": "bash change.sh 0 \"${coins[@]}\""
+    },
+    {
+      "name": "\"error testing for change smaller than the smallest of coins\"",
+      "cmd": "bash change.sh 3 \"${coins[@]}\""
+    },
+    {
+      "name": "\"error if no combination can add up to target\"",
+      "cmd": "bash change.sh 94 \"${coins[@]}\""
+    },
+    {
+      "name": "\"cannot find negative change values\"",
+      "cmd": "bash change.sh -5 \"${coins[@]}\""
+    }
+  ]
+}

--- a/exercises/change/.meta/config.json
+++ b/exercises/change/.meta/config.json
@@ -4,47 +4,47 @@
   ],
   "tests": [
     {
-      "name": "\"single coin change\"",
+      "name": "single coin change",
       "cmd": "bash change.sh 25 \"${coins[@]}\""
     },
     {
-      "name": "\"multiple coin change\"",
+      "name": "multiple coin change",
       "cmd": "bash change.sh 15 \"${coins[@]}\""
     },
     {
-      "name": "\"change with Lilliputian Coins\"",
+      "name": "change with Lilliputian Coins",
       "cmd": "bash change.sh 23 \"${coins[@]}\""
     },
     {
-      "name": "\"change with Lower Elbonia Coins\"",
+      "name": "change with Lower Elbonia Coins",
       "cmd": "bash change.sh 63 \"${coins[@]}\""
     },
     {
-      "name": "\"large target values\"",
+      "name": "large target values",
       "cmd": "bash change.sh 999 \"${coins[@]}\""
     },
     {
-      "name": "\"possible change without unit coins available\"",
+      "name": "possible change without unit coins available",
       "cmd": "bash change.sh 21 \"${coins[@]}\""
     },
     {
-      "name": "\"another possible change without unit coins available\"",
+      "name": "another possible change without unit coins available",
       "cmd": "bash change.sh 27 \"${coins[@]}\""
     },
     {
-      "name": "\"no coins make 0 change\"",
+      "name": "no coins make 0 change",
       "cmd": "bash change.sh 0 \"${coins[@]}\""
     },
     {
-      "name": "\"error testing for change smaller than the smallest of coins\"",
+      "name": "error testing for change smaller than the smallest of coins",
       "cmd": "bash change.sh 3 \"${coins[@]}\""
     },
     {
-      "name": "\"error if no combination can add up to target\"",
+      "name": "error if no combination can add up to target",
       "cmd": "bash change.sh 94 \"${coins[@]}\""
     },
     {
-      "name": "\"cannot find negative change values\"",
+      "name": "cannot find negative change values",
       "cmd": "bash change.sh -5 \"${coins[@]}\""
     }
   ]

--- a/exercises/clock/.meta/config.json
+++ b/exercises/clock/.meta/config.json
@@ -4,171 +4,171 @@
   ],
   "tests": [
     {
-      "name": "\"on the hour\"",
+      "name": "on the hour",
       "cmd": "bash clock.sh 8 0"
     },
     {
-      "name": "\"past the hour\"",
+      "name": "past the hour",
       "cmd": "bash clock.sh 11 9"
     },
     {
-      "name": "\"midnight is zero hours\"",
+      "name": "midnight is zero hours",
       "cmd": "bash clock.sh 24 0"
     },
     {
-      "name": "\"hour rolls over\"",
+      "name": "hour rolls over",
       "cmd": "bash clock.sh 25 0"
     },
     {
-      "name": "\"hour rolls over continuously\"",
+      "name": "hour rolls over continuously",
       "cmd": "bash clock.sh 100 0"
     },
     {
-      "name": "\"sixty minutes is next hour\"",
+      "name": "sixty minutes is next hour",
       "cmd": "bash clock.sh 1 60"
     },
     {
-      "name": "\"minutes roll over\"",
+      "name": "minutes roll over",
       "cmd": "bash clock.sh 0 160"
     },
     {
-      "name": "\"minutes roll over continuously\"",
+      "name": "minutes roll over continuously",
       "cmd": "bash clock.sh 0 1723"
     },
     {
-      "name": "\"hour and minutes roll over\"",
+      "name": "hour and minutes roll over",
       "cmd": "bash clock.sh 25 160"
     },
     {
-      "name": "\"hour and minutes roll over continuously\"",
+      "name": "hour and minutes roll over continuously",
       "cmd": "bash clock.sh 201 3001"
     },
     {
-      "name": "\"hour and minutes roll over to exactly midnight\"",
+      "name": "hour and minutes roll over to exactly midnight",
       "cmd": "bash clock.sh 72 8640"
     },
     {
-      "name": "\"negative hour\"",
+      "name": "negative hour",
       "cmd": "bash clock.sh -1 15"
     },
     {
-      "name": "\"negative hour rolls over\"",
+      "name": "negative hour rolls over",
       "cmd": "bash clock.sh -25 0"
     },
     {
-      "name": "\"negative hour rolls over continuously\"",
+      "name": "negative hour rolls over continuously",
       "cmd": "bash clock.sh -91 0"
     },
     {
-      "name": "\"negative minutes\"",
+      "name": "negative minutes",
       "cmd": "bash clock.sh 1 -40"
     },
     {
-      "name": "\"negative minutes roll over\"",
+      "name": "negative minutes roll over",
       "cmd": "bash clock.sh 1 -160"
     },
     {
-      "name": "\"negative minutes roll over continuously\"",
+      "name": "negative minutes roll over continuously",
       "cmd": "bash clock.sh 1 -4820"
     },
     {
-      "name": "\"negative sixty minutes is previous hour\"",
+      "name": "negative sixty minutes is previous hour",
       "cmd": "bash clock.sh 2 -60"
     },
     {
-      "name": "\"negative hour and minutes both roll over\"",
+      "name": "negative hour and minutes both roll over",
       "cmd": "bash clock.sh -25 -160"
     },
     {
-      "name": "\"negative hour and minutes both roll over continuously\"",
+      "name": "negative hour and minutes both roll over continuously",
       "cmd": "bash clock.sh -121 -5810"
     },
     {
-      "name": "\"add minutes\"",
+      "name": "add minutes",
       "cmd": "bash clock.sh 10 0 + 3"
     },
     {
-      "name": "\"add no minutes\"",
+      "name": "add no minutes",
       "cmd": "bash clock.sh 6 41 + 0"
     },
     {
-      "name": "\"add to next hour\"",
+      "name": "add to next hour",
       "cmd": "bash clock.sh 0 45 + 40"
     },
     {
-      "name": "\"add more than one hour\"",
+      "name": "add more than one hour",
       "cmd": "bash clock.sh 10 0 + 61"
     },
     {
-      "name": "\"add more than two hours with carry\"",
+      "name": "add more than two hours with carry",
       "cmd": "bash clock.sh 0 45 + 160"
     },
     {
-      "name": "\"add across midnight\"",
+      "name": "add across midnight",
       "cmd": "bash clock.sh 23 59 + 2"
     },
     {
-      "name": "\"add more than one day (1500 min = 25 hrs)\"",
+      "name": "add more than one day (1500 min = 25 hrs)",
       "cmd": "bash clock.sh 5 32 + 1500"
     },
     {
-      "name": "\"add more than two days\"",
+      "name": "add more than two days",
       "cmd": "bash clock.sh 1 1 + 3500"
     },
     {
-      "name": "\"subtract minutes\"",
+      "name": "subtract minutes",
       "cmd": "bash clock.sh 10 3 - 3"
     },
     {
-      "name": "\"subtract to previous hour\"",
+      "name": "subtract to previous hour",
       "cmd": "bash clock.sh 10 3 - 30"
     },
     {
-      "name": "\"subtract more than an hour\"",
+      "name": "subtract more than an hour",
       "cmd": "bash clock.sh 10 3 - 70"
     },
     {
-      "name": "\"subtract across midnight\"",
+      "name": "subtract across midnight",
       "cmd": "bash clock.sh 0 3 - 4"
     },
     {
-      "name": "\"subtract more than two hours\"",
+      "name": "subtract more than two hours",
       "cmd": "bash clock.sh 0 0 - 160"
     },
     {
-      "name": "\"subtract more than two hours with borrow\"",
+      "name": "subtract more than two hours with borrow",
       "cmd": "bash clock.sh 6 15 - 160"
     },
     {
-      "name": "\"subtract more than one day (1500 min = 25 hrs)\"",
+      "name": "subtract more than one day (1500 min = 25 hrs)",
       "cmd": "bash clock.sh 5 32 - 1500"
     },
     {
-      "name": "\"subtract more than two days\"",
+      "name": "subtract more than two days",
       "cmd": "bash clock.sh 2 20 - 3000"
     },
     {
-      "name": "\"no args\"",
+      "name": "no args",
       "cmd": "bash clock.sh"
     },
     {
-      "name": "\"too many args\"",
+      "name": "too many args",
       "cmd": "bash clock.sh 1 2 3 4 5"
     },
     {
-      "name": "\"three args\"",
+      "name": "three args",
       "cmd": "bash clock.sh 1 2 +"
     },
     {
-      "name": "\"invalid delta\"",
+      "name": "invalid delta",
       "cmd": "bash clock.sh 1 2 / 3"
     },
     {
-      "name": "\"non-numeric args are errors\"",
+      "name": "non-numeric args are errors",
       "cmd": "bash clock.sh foo bar"
     },
     {
-      "name": "\"non-numeric delta errors\"",
+      "name": "non-numeric delta errors",
       "cmd": "bash clock.sh 1 2 - 3delta"
     }
   ]

--- a/exercises/clock/.meta/config.json
+++ b/exercises/clock/.meta/config.json
@@ -1,0 +1,175 @@
+{
+  "solution_files": [
+    "clock.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"on the hour\"",
+      "cmd": "bash clock.sh 8 0"
+    },
+    {
+      "name": "\"past the hour\"",
+      "cmd": "bash clock.sh 11 9"
+    },
+    {
+      "name": "\"midnight is zero hours\"",
+      "cmd": "bash clock.sh 24 0"
+    },
+    {
+      "name": "\"hour rolls over\"",
+      "cmd": "bash clock.sh 25 0"
+    },
+    {
+      "name": "\"hour rolls over continuously\"",
+      "cmd": "bash clock.sh 100 0"
+    },
+    {
+      "name": "\"sixty minutes is next hour\"",
+      "cmd": "bash clock.sh 1 60"
+    },
+    {
+      "name": "\"minutes roll over\"",
+      "cmd": "bash clock.sh 0 160"
+    },
+    {
+      "name": "\"minutes roll over continuously\"",
+      "cmd": "bash clock.sh 0 1723"
+    },
+    {
+      "name": "\"hour and minutes roll over\"",
+      "cmd": "bash clock.sh 25 160"
+    },
+    {
+      "name": "\"hour and minutes roll over continuously\"",
+      "cmd": "bash clock.sh 201 3001"
+    },
+    {
+      "name": "\"hour and minutes roll over to exactly midnight\"",
+      "cmd": "bash clock.sh 72 8640"
+    },
+    {
+      "name": "\"negative hour\"",
+      "cmd": "bash clock.sh -1 15"
+    },
+    {
+      "name": "\"negative hour rolls over\"",
+      "cmd": "bash clock.sh -25 0"
+    },
+    {
+      "name": "\"negative hour rolls over continuously\"",
+      "cmd": "bash clock.sh -91 0"
+    },
+    {
+      "name": "\"negative minutes\"",
+      "cmd": "bash clock.sh 1 -40"
+    },
+    {
+      "name": "\"negative minutes roll over\"",
+      "cmd": "bash clock.sh 1 -160"
+    },
+    {
+      "name": "\"negative minutes roll over continuously\"",
+      "cmd": "bash clock.sh 1 -4820"
+    },
+    {
+      "name": "\"negative sixty minutes is previous hour\"",
+      "cmd": "bash clock.sh 2 -60"
+    },
+    {
+      "name": "\"negative hour and minutes both roll over\"",
+      "cmd": "bash clock.sh -25 -160"
+    },
+    {
+      "name": "\"negative hour and minutes both roll over continuously\"",
+      "cmd": "bash clock.sh -121 -5810"
+    },
+    {
+      "name": "\"add minutes\"",
+      "cmd": "bash clock.sh 10 0 + 3"
+    },
+    {
+      "name": "\"add no minutes\"",
+      "cmd": "bash clock.sh 6 41 + 0"
+    },
+    {
+      "name": "\"add to next hour\"",
+      "cmd": "bash clock.sh 0 45 + 40"
+    },
+    {
+      "name": "\"add more than one hour\"",
+      "cmd": "bash clock.sh 10 0 + 61"
+    },
+    {
+      "name": "\"add more than two hours with carry\"",
+      "cmd": "bash clock.sh 0 45 + 160"
+    },
+    {
+      "name": "\"add across midnight\"",
+      "cmd": "bash clock.sh 23 59 + 2"
+    },
+    {
+      "name": "\"add more than one day (1500 min = 25 hrs)\"",
+      "cmd": "bash clock.sh 5 32 + 1500"
+    },
+    {
+      "name": "\"add more than two days\"",
+      "cmd": "bash clock.sh 1 1 + 3500"
+    },
+    {
+      "name": "\"subtract minutes\"",
+      "cmd": "bash clock.sh 10 3 - 3"
+    },
+    {
+      "name": "\"subtract to previous hour\"",
+      "cmd": "bash clock.sh 10 3 - 30"
+    },
+    {
+      "name": "\"subtract more than an hour\"",
+      "cmd": "bash clock.sh 10 3 - 70"
+    },
+    {
+      "name": "\"subtract across midnight\"",
+      "cmd": "bash clock.sh 0 3 - 4"
+    },
+    {
+      "name": "\"subtract more than two hours\"",
+      "cmd": "bash clock.sh 0 0 - 160"
+    },
+    {
+      "name": "\"subtract more than two hours with borrow\"",
+      "cmd": "bash clock.sh 6 15 - 160"
+    },
+    {
+      "name": "\"subtract more than one day (1500 min = 25 hrs)\"",
+      "cmd": "bash clock.sh 5 32 - 1500"
+    },
+    {
+      "name": "\"subtract more than two days\"",
+      "cmd": "bash clock.sh 2 20 - 3000"
+    },
+    {
+      "name": "\"no args\"",
+      "cmd": "bash clock.sh"
+    },
+    {
+      "name": "\"too many args\"",
+      "cmd": "bash clock.sh 1 2 3 4 5"
+    },
+    {
+      "name": "\"three args\"",
+      "cmd": "bash clock.sh 1 2 +"
+    },
+    {
+      "name": "\"invalid delta\"",
+      "cmd": "bash clock.sh 1 2 / 3"
+    },
+    {
+      "name": "\"non-numeric args are errors\"",
+      "cmd": "bash clock.sh foo bar"
+    },
+    {
+      "name": "\"non-numeric delta errors\"",
+      "cmd": "bash clock.sh 1 2 - 3delta"
+    }
+  ]
+}

--- a/exercises/collatz-conjecture/.meta/config.json
+++ b/exercises/collatz-conjecture/.meta/config.json
@@ -4,27 +4,27 @@
   ],
   "tests": [
     {
-      "name": "\"zero steps for one\"",
+      "name": "zero steps for one",
       "cmd": "bash collatz_conjecture.sh 1"
     },
     {
-      "name": "\"divide if even\"",
+      "name": "divide if even",
       "cmd": "bash collatz_conjecture.sh 16"
     },
     {
-      "name": "\"even and odd steps\"",
+      "name": "even and odd steps",
       "cmd": "bash collatz_conjecture.sh 12"
     },
     {
-      "name": "\"large number of even and odd steps\"",
+      "name": "large number of even and odd steps",
       "cmd": "bash collatz_conjecture.sh 1000000"
     },
     {
-      "name": "\"zero is an error\"",
+      "name": "zero is an error",
       "cmd": "bash collatz_conjecture.sh 0"
     },
     {
-      "name": "\"negative value is an error\"",
+      "name": "negative value is an error",
       "cmd": "bash collatz_conjecture.sh -15"
     }
   ]

--- a/exercises/collatz-conjecture/.meta/config.json
+++ b/exercises/collatz-conjecture/.meta/config.json
@@ -1,0 +1,31 @@
+{
+  "solution_files": [
+    "collatz_conjecture.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"zero steps for one\"",
+      "cmd": "bash collatz_conjecture.sh 1"
+    },
+    {
+      "name": "\"divide if even\"",
+      "cmd": "bash collatz_conjecture.sh 16"
+    },
+    {
+      "name": "\"even and odd steps\"",
+      "cmd": "bash collatz_conjecture.sh 12"
+    },
+    {
+      "name": "\"large number of even and odd steps\"",
+      "cmd": "bash collatz_conjecture.sh 1000000"
+    },
+    {
+      "name": "\"zero is an error\"",
+      "cmd": "bash collatz_conjecture.sh 0"
+    },
+    {
+      "name": "\"negative value is an error\"",
+      "cmd": "bash collatz_conjecture.sh -15"
+    }
+  ]
+}

--- a/exercises/crypto-square/.meta/config.json
+++ b/exercises/crypto-square/.meta/config.json
@@ -4,31 +4,31 @@
   ],
   "tests": [
     {
-      "name": "\"empty plaintext results in an empty ciphertext\"",
+      "name": "empty plaintext results in an empty ciphertext",
       "cmd": "bash crypto_square.sh \"\""
     },
     {
-      "name": "\"Lowercase\"",
+      "name": "Lowercase",
       "cmd": "bash crypto_square.sh \"A\""
     },
     {
-      "name": "\"Remove spaces\"",
+      "name": "Remove spaces",
       "cmd": "bash crypto_square.sh \" b \""
     },
     {
-      "name": "\"Remove punctuation\"",
+      "name": "Remove punctuation",
       "cmd": "bash crypto_square.sh \"@1,%!\""
     },
     {
-      "name": "\"9 character plaintext results in 3 chunks of 3 characters\"",
+      "name": "9 character plaintext results in 3 chunks of 3 characters",
       "cmd": "bash crypto_square.sh \"This is fun!\""
     },
     {
-      "name": "\"8 character plaintext results in 3 chunks, the last one with a trailing space\"",
+      "name": "8 character plaintext results in 3 chunks, the last one with a trailing space",
       "cmd": "bash crypto_square.sh \"Chill out.\""
     },
     {
-      "name": "\"54 character plaintext results in 7 chunks, the last two with trailing spaces\"",
+      "name": "54 character plaintext results in 7 chunks, the last two with trailing spaces",
       "cmd": "bash crypto_square.sh \"If man was meant to stay on the ground, god would have given us roots.\""
     }
   ]

--- a/exercises/crypto-square/.meta/config.json
+++ b/exercises/crypto-square/.meta/config.json
@@ -1,0 +1,35 @@
+{
+  "solution_files": [
+    "crypto_square.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"empty plaintext results in an empty ciphertext\"",
+      "cmd": "bash crypto_square.sh \"\""
+    },
+    {
+      "name": "\"Lowercase\"",
+      "cmd": "bash crypto_square.sh \"A\""
+    },
+    {
+      "name": "\"Remove spaces\"",
+      "cmd": "bash crypto_square.sh \" b \""
+    },
+    {
+      "name": "\"Remove punctuation\"",
+      "cmd": "bash crypto_square.sh \"@1,%!\""
+    },
+    {
+      "name": "\"9 character plaintext results in 3 chunks of 3 characters\"",
+      "cmd": "bash crypto_square.sh \"This is fun!\""
+    },
+    {
+      "name": "\"8 character plaintext results in 3 chunks, the last one with a trailing space\"",
+      "cmd": "bash crypto_square.sh \"Chill out.\""
+    },
+    {
+      "name": "\"54 character plaintext results in 7 chunks, the last two with trailing spaces\"",
+      "cmd": "bash crypto_square.sh \"If man was meant to stay on the ground, god would have given us roots.\""
+    }
+  ]
+}

--- a/exercises/darts/.meta/config.json
+++ b/exercises/darts/.meta/config.json
@@ -1,0 +1,75 @@
+{
+  "solution_files": [
+    "darts.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Missed target\"",
+      "cmd": "bash darts.sh -9 9"
+    },
+    {
+      "name": "\"On the outer circle\"",
+      "cmd": "bash darts.sh 0 10"
+    },
+    {
+      "name": "\"On the middle circle\"",
+      "cmd": "bash darts.sh -5 0"
+    },
+    {
+      "name": "\"On the inner circle\"",
+      "cmd": "bash darts.sh 0 -1"
+    },
+    {
+      "name": "\"Exactly on centre\"",
+      "cmd": "bash darts.sh 0 0"
+    },
+    {
+      "name": "\"Near the centre\"",
+      "cmd": "bash darts.sh -0.1 -0.1"
+    },
+    {
+      "name": "\"Just within the inner circle\"",
+      "cmd": "bash darts.sh 0.7 0.7"
+    },
+    {
+      "name": "\"Just outside the inner circle\"",
+      "cmd": "bash darts.sh 0.8 -0.8"
+    },
+    {
+      "name": "\"Just within the middle circle\"",
+      "cmd": "bash darts.sh -3.5 3.5"
+    },
+    {
+      "name": "\"Just outside the middle circle\"",
+      "cmd": "bash darts.sh -3.6 -3.6"
+    },
+    {
+      "name": "\"Just within the outer circle\"",
+      "cmd": "bash darts.sh -7.0 7.0"
+    },
+    {
+      "name": "\"Just outside the outer circle\"",
+      "cmd": "bash darts.sh 7.1 -7.1"
+    },
+    {
+      "name": "\"Asymmetric position between the inner and middle circles\"",
+      "cmd": "bash darts.sh 0.5 -4"
+    },
+    {
+      "name": "\"invalid args: no args\"",
+      "cmd": "bash darts.sh"
+    },
+    {
+      "name": "\"invalid args: only 1 arg\"",
+      "cmd": "bash darts.sh 10"
+    },
+    {
+      "name": "\"invalid args: first arg non-numeric\"",
+      "cmd": "bash darts.sh foo 10"
+    },
+    {
+      "name": "\"invalid args: second arg non-numeric\"",
+      "cmd": "bash darts.sh 10 bar"
+    }
+  ]
+}

--- a/exercises/darts/.meta/config.json
+++ b/exercises/darts/.meta/config.json
@@ -4,71 +4,71 @@
   ],
   "tests": [
     {
-      "name": "\"Missed target\"",
+      "name": "Missed target",
       "cmd": "bash darts.sh -9 9"
     },
     {
-      "name": "\"On the outer circle\"",
+      "name": "On the outer circle",
       "cmd": "bash darts.sh 0 10"
     },
     {
-      "name": "\"On the middle circle\"",
+      "name": "On the middle circle",
       "cmd": "bash darts.sh -5 0"
     },
     {
-      "name": "\"On the inner circle\"",
+      "name": "On the inner circle",
       "cmd": "bash darts.sh 0 -1"
     },
     {
-      "name": "\"Exactly on centre\"",
+      "name": "Exactly on centre",
       "cmd": "bash darts.sh 0 0"
     },
     {
-      "name": "\"Near the centre\"",
+      "name": "Near the centre",
       "cmd": "bash darts.sh -0.1 -0.1"
     },
     {
-      "name": "\"Just within the inner circle\"",
+      "name": "Just within the inner circle",
       "cmd": "bash darts.sh 0.7 0.7"
     },
     {
-      "name": "\"Just outside the inner circle\"",
+      "name": "Just outside the inner circle",
       "cmd": "bash darts.sh 0.8 -0.8"
     },
     {
-      "name": "\"Just within the middle circle\"",
+      "name": "Just within the middle circle",
       "cmd": "bash darts.sh -3.5 3.5"
     },
     {
-      "name": "\"Just outside the middle circle\"",
+      "name": "Just outside the middle circle",
       "cmd": "bash darts.sh -3.6 -3.6"
     },
     {
-      "name": "\"Just within the outer circle\"",
+      "name": "Just within the outer circle",
       "cmd": "bash darts.sh -7.0 7.0"
     },
     {
-      "name": "\"Just outside the outer circle\"",
+      "name": "Just outside the outer circle",
       "cmd": "bash darts.sh 7.1 -7.1"
     },
     {
-      "name": "\"Asymmetric position between the inner and middle circles\"",
+      "name": "Asymmetric position between the inner and middle circles",
       "cmd": "bash darts.sh 0.5 -4"
     },
     {
-      "name": "\"invalid args: no args\"",
+      "name": "invalid args: no args",
       "cmd": "bash darts.sh"
     },
     {
-      "name": "\"invalid args: only 1 arg\"",
+      "name": "invalid args: only 1 arg",
       "cmd": "bash darts.sh 10"
     },
     {
-      "name": "\"invalid args: first arg non-numeric\"",
+      "name": "invalid args: first arg non-numeric",
       "cmd": "bash darts.sh foo 10"
     },
     {
-      "name": "\"invalid args: second arg non-numeric\"",
+      "name": "invalid args: second arg non-numeric",
       "cmd": "bash darts.sh 10 bar"
     }
   ]

--- a/exercises/diamond/.meta/config.json
+++ b/exercises/diamond/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "diamond.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Degenerate case with a single 'A' row\"",
+      "cmd": "bash diamond.sh A"
+    },
+    {
+      "name": "\"Degenerate case with no row containing 3 distinct groups of spaces\"",
+      "cmd": "bash diamond.sh B"
+    },
+    {
+      "name": "\"Smallest non-degenerate case with odd diamond side length\"",
+      "cmd": "bash diamond.sh C"
+    },
+    {
+      "name": "\"Smallest non-degenerate case with even diamond side length\"",
+      "cmd": "bash diamond.sh D"
+    },
+    {
+      "name": "\"Largest possible diamond\"",
+      "cmd": "bash diamond.sh Z"
+    }
+  ]
+}

--- a/exercises/diamond/.meta/config.json
+++ b/exercises/diamond/.meta/config.json
@@ -4,23 +4,23 @@
   ],
   "tests": [
     {
-      "name": "\"Degenerate case with a single 'A' row\"",
+      "name": "Degenerate case with a single 'A' row",
       "cmd": "bash diamond.sh A"
     },
     {
-      "name": "\"Degenerate case with no row containing 3 distinct groups of spaces\"",
+      "name": "Degenerate case with no row containing 3 distinct groups of spaces",
       "cmd": "bash diamond.sh B"
     },
     {
-      "name": "\"Smallest non-degenerate case with odd diamond side length\"",
+      "name": "Smallest non-degenerate case with odd diamond side length",
       "cmd": "bash diamond.sh C"
     },
     {
-      "name": "\"Smallest non-degenerate case with even diamond side length\"",
+      "name": "Smallest non-degenerate case with even diamond side length",
       "cmd": "bash diamond.sh D"
     },
     {
-      "name": "\"Largest possible diamond\"",
+      "name": "Largest possible diamond",
       "cmd": "bash diamond.sh Z"
     }
   ]

--- a/exercises/difference-of-squares/.meta/config.json
+++ b/exercises/difference-of-squares/.meta/config.json
@@ -1,0 +1,43 @@
+{
+  "solution_files": [
+    "difference_of_squares.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"square of sum 1\"",
+      "cmd": "bash difference_of_squares.sh square_of_sum 1"
+    },
+    {
+      "name": "\"square of sum 5\"",
+      "cmd": "bash difference_of_squares.sh square_of_sum 5"
+    },
+    {
+      "name": "\"square of sum 100\"",
+      "cmd": "bash difference_of_squares.sh square_of_sum 100"
+    },
+    {
+      "name": "\"sum of squares 1\"",
+      "cmd": "bash difference_of_squares.sh sum_of_squares 1"
+    },
+    {
+      "name": "\"sum of squares 5\"",
+      "cmd": "bash difference_of_squares.sh sum_of_squares 5"
+    },
+    {
+      "name": "\"sum of squares 100\"",
+      "cmd": "bash difference_of_squares.sh sum_of_squares 100"
+    },
+    {
+      "name": "\"difference of squares 1\"",
+      "cmd": "bash difference_of_squares.sh difference 1"
+    },
+    {
+      "name": "\"difference of squares 5\"",
+      "cmd": "bash difference_of_squares.sh difference 5"
+    },
+    {
+      "name": "\"difference of squares 100\"",
+      "cmd": "bash difference_of_squares.sh difference 100"
+    }
+  ]
+}

--- a/exercises/difference-of-squares/.meta/config.json
+++ b/exercises/difference-of-squares/.meta/config.json
@@ -4,39 +4,39 @@
   ],
   "tests": [
     {
-      "name": "\"square of sum 1\"",
+      "name": "square of sum 1",
       "cmd": "bash difference_of_squares.sh square_of_sum 1"
     },
     {
-      "name": "\"square of sum 5\"",
+      "name": "square of sum 5",
       "cmd": "bash difference_of_squares.sh square_of_sum 5"
     },
     {
-      "name": "\"square of sum 100\"",
+      "name": "square of sum 100",
       "cmd": "bash difference_of_squares.sh square_of_sum 100"
     },
     {
-      "name": "\"sum of squares 1\"",
+      "name": "sum of squares 1",
       "cmd": "bash difference_of_squares.sh sum_of_squares 1"
     },
     {
-      "name": "\"sum of squares 5\"",
+      "name": "sum of squares 5",
       "cmd": "bash difference_of_squares.sh sum_of_squares 5"
     },
     {
-      "name": "\"sum of squares 100\"",
+      "name": "sum of squares 100",
       "cmd": "bash difference_of_squares.sh sum_of_squares 100"
     },
     {
-      "name": "\"difference of squares 1\"",
+      "name": "difference of squares 1",
       "cmd": "bash difference_of_squares.sh difference 1"
     },
     {
-      "name": "\"difference of squares 5\"",
+      "name": "difference of squares 5",
       "cmd": "bash difference_of_squares.sh difference 5"
     },
     {
-      "name": "\"difference of squares 100\"",
+      "name": "difference of squares 100",
       "cmd": "bash difference_of_squares.sh difference 100"
     }
   ]

--- a/exercises/diffie-hellman/.meta/config.json
+++ b/exercises/diffie-hellman/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "diffie_hellman.sh"
+  ],
+  "tests": [
+    {
+      "name": "private key is in range",
+      "cmd": "bash diffie_hellman.sh privateKey $i"
+    },
+    {
+      "name": "private key is random",
+      "cmd": "bash diffie_hellman.sh privateKey $p"
+    },
+    {
+      "name": "can calculate public key using private key",
+      "cmd": "bash diffie_hellman.sh publicKey $p $g $private"
+    },
+    {
+      "name": "can calculate secret key using other's public key",
+      "cmd": "bash diffie_hellman.sh secret $p $public $private"
+    },
+    {
+      "name": "key exchange",
+      "cmd": "bash diffie_hellman.sh privateKey $p"
+    }
+  ]
+}

--- a/exercises/dnd-character/.meta/config.json
+++ b/exercises/dnd-character/.meta/config.json
@@ -73,7 +73,7 @@
     },
     {
       "name": "validate ability and hitpoint range",
-      "cmd": "< <( run bash dnd_character.sh generate )"
+      "cmd": "bash dnd_character.sh generate"
     }
   ]
 }

--- a/exercises/dnd-character/.meta/config.json
+++ b/exercises/dnd-character/.meta/config.json
@@ -1,0 +1,79 @@
+{
+  "solution_files": [
+    "dnd_character.sh"
+  ],
+  "tests": [
+    {
+      "name": "ability modifier for score 3 is -4",
+      "cmd": "bash dnd_character.sh modifier 3"
+    },
+    {
+      "name": "ability modifier for score 4 is -3",
+      "cmd": "bash dnd_character.sh modifier 4"
+    },
+    {
+      "name": "ability modifier for score 5 is -3",
+      "cmd": "bash dnd_character.sh modifier 5"
+    },
+    {
+      "name": "ability modifier for score 6 is -2",
+      "cmd": "bash dnd_character.sh modifier 6"
+    },
+    {
+      "name": "ability modifier for score 7 is -2",
+      "cmd": "bash dnd_character.sh modifier 7"
+    },
+    {
+      "name": "ability modifier for score 8 is -1",
+      "cmd": "bash dnd_character.sh modifier 8"
+    },
+    {
+      "name": "ability modifier for score 9 is -1",
+      "cmd": "bash dnd_character.sh modifier 9"
+    },
+    {
+      "name": "ability modifier for score 10 is 0",
+      "cmd": "bash dnd_character.sh modifier 10"
+    },
+    {
+      "name": "ability modifier for score 11 is 0",
+      "cmd": "bash dnd_character.sh modifier 11"
+    },
+    {
+      "name": "ability modifier for score 12 is +1",
+      "cmd": "bash dnd_character.sh modifier 12"
+    },
+    {
+      "name": "ability modifier for score 13 is +1",
+      "cmd": "bash dnd_character.sh modifier 13"
+    },
+    {
+      "name": "ability modifier for score 14 is +2",
+      "cmd": "bash dnd_character.sh modifier 14"
+    },
+    {
+      "name": "ability modifier for score 15 is +2",
+      "cmd": "bash dnd_character.sh modifier 15"
+    },
+    {
+      "name": "ability modifier for score 16 is +3",
+      "cmd": "bash dnd_character.sh modifier 16"
+    },
+    {
+      "name": "ability modifier for score 17 is +3",
+      "cmd": "bash dnd_character.sh modifier 17"
+    },
+    {
+      "name": "ability modifier for score 18 is +4",
+      "cmd": "bash dnd_character.sh modifier 18"
+    },
+    {
+      "name": "generate a character",
+      "cmd": "bash dnd_character.sh generate"
+    },
+    {
+      "name": "validate ability and hitpoint range",
+      "cmd": "< <( run bash dnd_character.sh generate )"
+    }
+  ]
+}

--- a/exercises/error-handling/.meta/config.json
+++ b/exercises/error-handling/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "error_handling.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"correct arguments\"",
+      "cmd": "bash error_handling.sh Alice"
+    },
+    {
+      "name": "\"one long argument\"",
+      "cmd": "bash error_handling.sh \"Alice and Bob\""
+    },
+    {
+      "name": "\"incorrect arguments\"",
+      "cmd": "bash error_handling.sh Alice Bob"
+    },
+    {
+      "name": "\"print usage banner with no value given\"",
+      "cmd": "bash error_handling.sh"
+    },
+    {
+      "name": "\"empty argument\"",
+      "cmd": "bash error_handling.sh \"\""
+    }
+  ]
+}

--- a/exercises/error-handling/.meta/config.json
+++ b/exercises/error-handling/.meta/config.json
@@ -4,23 +4,23 @@
   ],
   "tests": [
     {
-      "name": "\"correct arguments\"",
+      "name": "correct arguments",
       "cmd": "bash error_handling.sh Alice"
     },
     {
-      "name": "\"one long argument\"",
+      "name": "one long argument",
       "cmd": "bash error_handling.sh \"Alice and Bob\""
     },
     {
-      "name": "\"incorrect arguments\"",
+      "name": "incorrect arguments",
       "cmd": "bash error_handling.sh Alice Bob"
     },
     {
-      "name": "\"print usage banner with no value given\"",
+      "name": "print usage banner with no value given",
       "cmd": "bash error_handling.sh"
     },
     {
-      "name": "\"empty argument\"",
+      "name": "empty argument",
       "cmd": "bash error_handling.sh \"\""
     }
   ]

--- a/exercises/food-chain/.meta/config.json
+++ b/exercises/food-chain/.meta/config.json
@@ -4,55 +4,55 @@
   ],
   "tests": [
     {
-      "name": "'fly'",
+      "name": "fly",
       "cmd": "bash food_chain.sh 1 1"
     },
     {
-      "name": "'spider'",
+      "name": "spider",
       "cmd": "bash food_chain.sh 2 2"
     },
     {
-      "name": "'bird'",
+      "name": "bird",
       "cmd": "bash food_chain.sh 3 3"
     },
     {
-      "name": "'cat'",
+      "name": "cat",
       "cmd": "bash food_chain.sh 4 4"
     },
     {
-      "name": "'dog'",
+      "name": "dog",
       "cmd": "bash food_chain.sh 5 5"
     },
     {
-      "name": "'goat'",
+      "name": "goat",
       "cmd": "bash food_chain.sh 6 6"
     },
     {
-      "name": "'cow'",
+      "name": "cow",
       "cmd": "bash food_chain.sh 7 7"
     },
     {
-      "name": "'horse'",
+      "name": "horse",
       "cmd": "bash food_chain.sh 8 8"
     },
     {
-      "name": "'multiple_verses'",
+      "name": "multiple_verses",
       "cmd": "bash food_chain.sh 1 3"
     },
     {
-      "name": "'full_song'",
+      "name": "full_song",
       "cmd": "bash food_chain.sh 1 8"
     },
     {
-      "name": "'no_arguments'",
+      "name": "no_arguments",
       "cmd": "bash food_chain.sh"
     },
     {
-      "name": "'too_many_arguments'",
+      "name": "too_many_arguments",
       "cmd": "bash food_chain.sh 1 2 3"
     },
     {
-      "name": "'wrong_order_arguments'",
+      "name": "wrong_order_arguments",
       "cmd": "bash food_chain.sh 8 1"
     }
   ]

--- a/exercises/food-chain/.meta/config.json
+++ b/exercises/food-chain/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "food_chain.sh"
+  ],
+  "tests": [
+    {
+      "name": "'fly'",
+      "cmd": "bash food_chain.sh 1 1"
+    },
+    {
+      "name": "'spider'",
+      "cmd": "bash food_chain.sh 2 2"
+    },
+    {
+      "name": "'bird'",
+      "cmd": "bash food_chain.sh 3 3"
+    },
+    {
+      "name": "'cat'",
+      "cmd": "bash food_chain.sh 4 4"
+    },
+    {
+      "name": "'dog'",
+      "cmd": "bash food_chain.sh 5 5"
+    },
+    {
+      "name": "'goat'",
+      "cmd": "bash food_chain.sh 6 6"
+    },
+    {
+      "name": "'cow'",
+      "cmd": "bash food_chain.sh 7 7"
+    },
+    {
+      "name": "'horse'",
+      "cmd": "bash food_chain.sh 8 8"
+    },
+    {
+      "name": "'multiple_verses'",
+      "cmd": "bash food_chain.sh 1 3"
+    },
+    {
+      "name": "'full_song'",
+      "cmd": "bash food_chain.sh 1 8"
+    },
+    {
+      "name": "'no_arguments'",
+      "cmd": "bash food_chain.sh"
+    },
+    {
+      "name": "'too_many_arguments'",
+      "cmd": "bash food_chain.sh 1 2 3"
+    },
+    {
+      "name": "'wrong_order_arguments'",
+      "cmd": "bash food_chain.sh 8 1"
+    }
+  ]
+}

--- a/exercises/forth/.meta/config.json
+++ b/exercises/forth/.meta/config.json
@@ -1,0 +1,199 @@
+{
+  "solution_files": [
+    "forth.sh"
+  ],
+  "tests": [
+    {
+      "name": "numbers_only",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "addition_ok",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "addition_no_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "addition_one_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "subtraction_ok",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "subtraction_no_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "subtraction_one_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "multiplication_ok",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "multiplication_no_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "multiplication_one_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "division_ok",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "division_int_result",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "division_no_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "division_one_args",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "division_by_zero",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "add_and_subtract",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "multiply_and_divide",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "dup_1",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "dup_2",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "dup_empty",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "drop_1",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "drop_2",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "drop_empty",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "swap_1",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "swap_2",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "swap_empty",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "swap_1arg",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "over_1",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "over_2",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "over_empty",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "over_1arg",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_with_builtin",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_maintain_order",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_can_override_macro",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_can_override_builtin",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_can_override_operator",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_expand_in_macro_definition",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_empty_definition",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_expand_in_macro_redefinition",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_cannot_redefine_numbers",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_undefined",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "macro_missing_semicolon",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "case_dup",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "case_drop",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "case_swap",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "case_over",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "case_macro_names",
+      "cmd": "bash forth.sh <<END"
+    },
+    {
+      "name": "case_macro_definitions",
+      "cmd": "bash forth.sh <<END"
+    }
+  ]
+}

--- a/exercises/gigasecond/.meta/config.json
+++ b/exercises/gigasecond/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "gigasecond.sh"
+  ],
+  "tests": [
+    {
+      "name": "'date only specificaion of time'",
+      "cmd": "bash gigasecond.sh '2011-04-25'"
+    },
+    {
+      "name": "'second test for date only specification of time'",
+      "cmd": "bash gigasecond.sh '1977-06-13'"
+    },
+    {
+      "name": "'third test for date only specification of time'",
+      "cmd": "bash gigasecond.sh '1959-07-19'"
+    },
+    {
+      "name": "'full time specified'",
+      "cmd": "bash gigasecond.sh '2015-01-24T22:00:00'"
+    },
+    {
+      "name": "'full time with day roll-over'",
+      "cmd": "bash gigasecond.sh '2015-01-24T23:59:59'"
+    }
+  ]
+}

--- a/exercises/gigasecond/.meta/config.json
+++ b/exercises/gigasecond/.meta/config.json
@@ -4,23 +4,23 @@
   ],
   "tests": [
     {
-      "name": "'date only specificaion of time'",
+      "name": "date only specificaion of time",
       "cmd": "bash gigasecond.sh '2011-04-25'"
     },
     {
-      "name": "'second test for date only specification of time'",
+      "name": "second test for date only specification of time",
       "cmd": "bash gigasecond.sh '1977-06-13'"
     },
     {
-      "name": "'third test for date only specification of time'",
+      "name": "third test for date only specification of time",
       "cmd": "bash gigasecond.sh '1959-07-19'"
     },
     {
-      "name": "'full time specified'",
+      "name": "full time specified",
       "cmd": "bash gigasecond.sh '2015-01-24T22:00:00'"
     },
     {
-      "name": "'full time with day roll-over'",
+      "name": "full time with day roll-over",
       "cmd": "bash gigasecond.sh '2015-01-24T23:59:59'"
     }
   ]

--- a/exercises/grains/.meta/config.json
+++ b/exercises/grains/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "grains.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"1\"",
+      "cmd": "bash grains.sh 1"
+    },
+    {
+      "name": "\"2\"",
+      "cmd": "bash grains.sh 2"
+    },
+    {
+      "name": "\"3\"",
+      "cmd": "bash grains.sh 3"
+    },
+    {
+      "name": "\"4\"",
+      "cmd": "bash grains.sh 4"
+    },
+    {
+      "name": "\"16\"",
+      "cmd": "bash grains.sh 16"
+    },
+    {
+      "name": "\"32\"",
+      "cmd": "bash grains.sh 32"
+    },
+    {
+      "name": "\"64\"",
+      "cmd": "bash grains.sh 64"
+    },
+    {
+      "name": "\"square 0 raises an exception\"",
+      "cmd": "bash grains.sh 0"
+    },
+    {
+      "name": "\"negative square raises an exception\"",
+      "cmd": "bash grains.sh -1"
+    },
+    {
+      "name": "\"square greater than 64 raises an exception\"",
+      "cmd": "bash grains.sh 65"
+    },
+    {
+      "name": "\"returns the total number of grains on the board\"",
+      "cmd": "bash grains.sh total"
+    }
+  ]
+}

--- a/exercises/grains/.meta/config.json
+++ b/exercises/grains/.meta/config.json
@@ -4,47 +4,47 @@
   ],
   "tests": [
     {
-      "name": "\"1\"",
+      "name": "1",
       "cmd": "bash grains.sh 1"
     },
     {
-      "name": "\"2\"",
+      "name": "2",
       "cmd": "bash grains.sh 2"
     },
     {
-      "name": "\"3\"",
+      "name": "3",
       "cmd": "bash grains.sh 3"
     },
     {
-      "name": "\"4\"",
+      "name": "4",
       "cmd": "bash grains.sh 4"
     },
     {
-      "name": "\"16\"",
+      "name": "16",
       "cmd": "bash grains.sh 16"
     },
     {
-      "name": "\"32\"",
+      "name": "32",
       "cmd": "bash grains.sh 32"
     },
     {
-      "name": "\"64\"",
+      "name": "64",
       "cmd": "bash grains.sh 64"
     },
     {
-      "name": "\"square 0 raises an exception\"",
+      "name": "square 0 raises an exception",
       "cmd": "bash grains.sh 0"
     },
     {
-      "name": "\"negative square raises an exception\"",
+      "name": "negative square raises an exception",
       "cmd": "bash grains.sh -1"
     },
     {
-      "name": "\"square greater than 64 raises an exception\"",
+      "name": "square greater than 64 raises an exception",
       "cmd": "bash grains.sh 65"
     },
     {
-      "name": "\"returns the total number of grains on the board\"",
+      "name": "returns the total number of grains on the board",
       "cmd": "bash grains.sh total"
     }
   ]

--- a/exercises/grep/.meta/config.json
+++ b/exercises/grep/.meta/config.json
@@ -1,0 +1,107 @@
+{
+  "solution_files": [
+    "grep.sh"
+  ],
+  "tests": [
+    {
+      "name": "One file, one match, no flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, one match, print line numbers flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, one match, case-insensitive flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, one match, print file names flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, one match, match entire lines flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, one match, multiple flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, several matches, no flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, several matches, print line numbers flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, several matches, match entire lines flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, several matches, case-insensitive flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, several matches, inverted flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, no matches, various flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, one match, file flag takes precedence over line flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "One file, several matches, inverted and match entire lines flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, one match, no flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, several matches, no flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, several matches, print line numbers flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, one match, print file names flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, several matches, case-insensitive flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, several matches, inverted flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, one match, match entire lines flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, one match, multiple flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, no matches, various flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, several matches, file flag takes precedence over line number flag",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    },
+    {
+      "name": "Multiple files, several matches, inverted and match entire lines flags",
+      "cmd": "bash grep.sh \"${flags[@]}\" \"$pattern\" \"${files[@]}\""
+    }
+  ]
+}

--- a/exercises/hamming/.meta/config.json
+++ b/exercises/hamming/.meta/config.json
@@ -1,0 +1,55 @@
+{
+  "solution_files": [
+    "hamming.sh"
+  ],
+  "tests": [
+    {
+      "name": "'empty strands'",
+      "cmd": "bash hamming.sh '' ''"
+    },
+    {
+      "name": "'single letter identical strands'",
+      "cmd": "bash hamming.sh 'A' 'A'"
+    },
+    {
+      "name": "'single letter different strands'",
+      "cmd": "bash hamming.sh 'G' 'T'"
+    },
+    {
+      "name": "'long identical strands'",
+      "cmd": "bash hamming.sh 'GGACTGAAATCTG' 'GGACTGAAATCTG'"
+    },
+    {
+      "name": "'long different strands'",
+      "cmd": "bash hamming.sh 'GGACGGATTCTG' 'AGGACGGATTCT'"
+    },
+    {
+      "name": "'disallow first strand longer'",
+      "cmd": "bash hamming.sh 'AATG' 'AAA'"
+    },
+    {
+      "name": "'disallow second strand longer'",
+      "cmd": "bash hamming.sh 'ATA' 'AGTG'"
+    },
+    {
+      "name": "'disallow left empty strand'",
+      "cmd": "bash hamming.sh '' 'G'"
+    },
+    {
+      "name": "'disallow right empty strand'",
+      "cmd": "bash hamming.sh 'G' ''"
+    },
+    {
+      "name": "\"no input\"",
+      "cmd": "bash hamming.sh"
+    },
+    {
+      "name": "\"invalid input\"",
+      "cmd": "bash hamming.sh 'A'"
+    },
+    {
+      "name": "\"expose subtle '[[ \\$x == \\$y ]]' bug\"",
+      "cmd": "bash hamming.sh 'AAA' 'A?A'"
+    }
+  ]
+}

--- a/exercises/hamming/.meta/config.json
+++ b/exercises/hamming/.meta/config.json
@@ -4,51 +4,51 @@
   ],
   "tests": [
     {
-      "name": "'empty strands'",
+      "name": "empty strands",
       "cmd": "bash hamming.sh '' ''"
     },
     {
-      "name": "'single letter identical strands'",
+      "name": "single letter identical strands",
       "cmd": "bash hamming.sh 'A' 'A'"
     },
     {
-      "name": "'single letter different strands'",
+      "name": "single letter different strands",
       "cmd": "bash hamming.sh 'G' 'T'"
     },
     {
-      "name": "'long identical strands'",
+      "name": "long identical strands",
       "cmd": "bash hamming.sh 'GGACTGAAATCTG' 'GGACTGAAATCTG'"
     },
     {
-      "name": "'long different strands'",
+      "name": "long different strands",
       "cmd": "bash hamming.sh 'GGACGGATTCTG' 'AGGACGGATTCT'"
     },
     {
-      "name": "'disallow first strand longer'",
+      "name": "disallow first strand longer",
       "cmd": "bash hamming.sh 'AATG' 'AAA'"
     },
     {
-      "name": "'disallow second strand longer'",
+      "name": "disallow second strand longer",
       "cmd": "bash hamming.sh 'ATA' 'AGTG'"
     },
     {
-      "name": "'disallow left empty strand'",
+      "name": "disallow left empty strand",
       "cmd": "bash hamming.sh '' 'G'"
     },
     {
-      "name": "'disallow right empty strand'",
+      "name": "disallow right empty strand",
       "cmd": "bash hamming.sh 'G' ''"
     },
     {
-      "name": "\"no input\"",
+      "name": "no input",
       "cmd": "bash hamming.sh"
     },
     {
-      "name": "\"invalid input\"",
+      "name": "invalid input",
       "cmd": "bash hamming.sh 'A'"
     },
     {
-      "name": "\"expose subtle '[[ \\$x == \\$y ]]' bug\"",
+      "name": "expose subtle '[[ \\$x == \\$y ]]' bug",
       "cmd": "bash hamming.sh 'AAA' 'A?A'"
     }
   ]

--- a/exercises/hello-world/.meta/config.json
+++ b/exercises/hello-world/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "solution_files": [
+    "hello_world.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Say Hi!\"",
+      "cmd": "bash hello_world.sh"
+    }
+  ]
+}

--- a/exercises/hello-world/.meta/config.json
+++ b/exercises/hello-world/.meta/config.json
@@ -4,7 +4,7 @@
   ],
   "tests": [
     {
-      "name": "\"Say Hi!\"",
+      "name": "Say Hi!",
       "cmd": "bash hello_world.sh"
     }
   ]

--- a/exercises/house/.meta/config.json
+++ b/exercises/house/.meta/config.json
@@ -1,0 +1,79 @@
+{
+  "solution_files": [
+    "house.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"verse 1\"",
+      "cmd": "bash house.sh 1 1"
+    },
+    {
+      "name": "\"verse 2\"",
+      "cmd": "bash house.sh 2 2"
+    },
+    {
+      "name": "\"verse 3\"",
+      "cmd": "bash house.sh 3 3"
+    },
+    {
+      "name": "\"verse 4\"",
+      "cmd": "bash house.sh 4 4"
+    },
+    {
+      "name": "\"verse 5\"",
+      "cmd": "bash house.sh 5 5"
+    },
+    {
+      "name": "\"verse 6\"",
+      "cmd": "bash house.sh 6 6"
+    },
+    {
+      "name": "\"verse 7\"",
+      "cmd": "bash house.sh 7 7"
+    },
+    {
+      "name": "\"verse 8\"",
+      "cmd": "bash house.sh 8 8"
+    },
+    {
+      "name": "\"verse 9\"",
+      "cmd": "bash house.sh 9 9"
+    },
+    {
+      "name": "\"verse 10\"",
+      "cmd": "bash house.sh 10 10"
+    },
+    {
+      "name": "\"verse 11\"",
+      "cmd": "bash house.sh 11 11"
+    },
+    {
+      "name": "\"verse 12\"",
+      "cmd": "bash house.sh 12 12"
+    },
+    {
+      "name": "\"verses 4 to 8\"",
+      "cmd": "bash house.sh 4 8"
+    },
+    {
+      "name": "\"all verses\"",
+      "cmd": "bash house.sh 1 12"
+    },
+    {
+      "name": "\"invalid verse 1\"",
+      "cmd": "bash house.sh 0 12"
+    },
+    {
+      "name": "\"invalid verse 2\"",
+      "cmd": "bash house.sh 1 -1"
+    },
+    {
+      "name": "\"invalid verse 3\"",
+      "cmd": "bash house.sh 14 12"
+    },
+    {
+      "name": "\"invalid verse 4\"",
+      "cmd": "bash house.sh 1 13"
+    }
+  ]
+}

--- a/exercises/house/.meta/config.json
+++ b/exercises/house/.meta/config.json
@@ -4,75 +4,75 @@
   ],
   "tests": [
     {
-      "name": "\"verse 1\"",
+      "name": "verse 1",
       "cmd": "bash house.sh 1 1"
     },
     {
-      "name": "\"verse 2\"",
+      "name": "verse 2",
       "cmd": "bash house.sh 2 2"
     },
     {
-      "name": "\"verse 3\"",
+      "name": "verse 3",
       "cmd": "bash house.sh 3 3"
     },
     {
-      "name": "\"verse 4\"",
+      "name": "verse 4",
       "cmd": "bash house.sh 4 4"
     },
     {
-      "name": "\"verse 5\"",
+      "name": "verse 5",
       "cmd": "bash house.sh 5 5"
     },
     {
-      "name": "\"verse 6\"",
+      "name": "verse 6",
       "cmd": "bash house.sh 6 6"
     },
     {
-      "name": "\"verse 7\"",
+      "name": "verse 7",
       "cmd": "bash house.sh 7 7"
     },
     {
-      "name": "\"verse 8\"",
+      "name": "verse 8",
       "cmd": "bash house.sh 8 8"
     },
     {
-      "name": "\"verse 9\"",
+      "name": "verse 9",
       "cmd": "bash house.sh 9 9"
     },
     {
-      "name": "\"verse 10\"",
+      "name": "verse 10",
       "cmd": "bash house.sh 10 10"
     },
     {
-      "name": "\"verse 11\"",
+      "name": "verse 11",
       "cmd": "bash house.sh 11 11"
     },
     {
-      "name": "\"verse 12\"",
+      "name": "verse 12",
       "cmd": "bash house.sh 12 12"
     },
     {
-      "name": "\"verses 4 to 8\"",
+      "name": "verses 4 to 8",
       "cmd": "bash house.sh 4 8"
     },
     {
-      "name": "\"all verses\"",
+      "name": "all verses",
       "cmd": "bash house.sh 1 12"
     },
     {
-      "name": "\"invalid verse 1\"",
+      "name": "invalid verse 1",
       "cmd": "bash house.sh 0 12"
     },
     {
-      "name": "\"invalid verse 2\"",
+      "name": "invalid verse 2",
       "cmd": "bash house.sh 1 -1"
     },
     {
-      "name": "\"invalid verse 3\"",
+      "name": "invalid verse 3",
       "cmd": "bash house.sh 14 12"
     },
     {
-      "name": "\"invalid verse 4\"",
+      "name": "invalid verse 4",
       "cmd": "bash house.sh 1 13"
     }
   ]

--- a/exercises/isbn-verifier/.meta/config.json
+++ b/exercises/isbn-verifier/.meta/config.json
@@ -4,71 +4,71 @@
   ],
   "tests": [
     {
-      "name": "'valid isbn number'",
+      "name": "valid isbn number",
       "cmd": "bash isbn_verifier.sh '3-598-21508-8'"
     },
     {
-      "name": "'invalid isbn check digit'",
+      "name": "invalid isbn check digit",
       "cmd": "bash isbn_verifier.sh '3-598-21508-9'"
     },
     {
-      "name": "'valid isbn number with a check digit of 10'",
+      "name": "valid isbn number with a check digit of 10",
       "cmd": "bash isbn_verifier.sh '3-598-21507-X'"
     },
     {
-      "name": "'check digit is a character other than X'",
+      "name": "check digit is a character other than X",
       "cmd": "bash isbn_verifier.sh '3-598-21507-A'"
     },
     {
-      "name": "'invalid character in isbn'",
+      "name": "invalid character in isbn",
       "cmd": "bash isbn_verifier.sh '3-598-P1581-X'"
     },
     {
-      "name": "'X is only valid as a check digit'",
+      "name": "X is only valid as a check digit",
       "cmd": "bash isbn_verifier.sh '3-598-2X507-9'"
     },
     {
-      "name": "'valid isbn without separating dashes'",
+      "name": "valid isbn without separating dashes",
       "cmd": "bash isbn_verifier.sh '3598215088'"
     },
     {
-      "name": "'isbn without separating dashes and X as check digit'",
+      "name": "isbn without separating dashes and X as check digit",
       "cmd": "bash isbn_verifier.sh '359821507X'"
     },
     {
-      "name": "'isbn without check digit and dashes'",
+      "name": "isbn without check digit and dashes",
       "cmd": "bash isbn_verifier.sh '359821507'"
     },
     {
-      "name": "'too long isbn and no dashes'",
+      "name": "too long isbn and no dashes",
       "cmd": "bash isbn_verifier.sh '3598215078X'"
     },
     {
-      "name": "'too short isbn'",
+      "name": "too short isbn",
       "cmd": "bash isbn_verifier.sh '00'"
     },
     {
-      "name": "'isbn without check digit'",
+      "name": "isbn without check digit",
       "cmd": "bash isbn_verifier.sh '3-598-21507'"
     },
     {
-      "name": "'check digit of X should not be used for 0'",
+      "name": "check digit of X should not be used for 0",
       "cmd": "bash isbn_verifier.sh '3-598-21515-X'"
     },
     {
-      "name": "'empty isbn'",
+      "name": "empty isbn",
       "cmd": "bash isbn_verifier.sh ''"
     },
     {
-      "name": "'input is 9 characters'",
+      "name": "input is 9 characters",
       "cmd": "bash isbn_verifier.sh '134456729'"
     },
     {
-      "name": "'invalid characters are not ignored'",
+      "name": "invalid characters are not ignored",
       "cmd": "bash isbn_verifier.sh '3132P34035'"
     },
     {
-      "name": "'input is too long but contains a valid isbn'",
+      "name": "input is too long but contains a valid isbn",
       "cmd": "bash isbn_verifier.sh '98245726788'"
     }
   ]

--- a/exercises/isbn-verifier/.meta/config.json
+++ b/exercises/isbn-verifier/.meta/config.json
@@ -1,0 +1,75 @@
+{
+  "solution_files": [
+    "isbn_verifier.sh"
+  ],
+  "tests": [
+    {
+      "name": "'valid isbn number'",
+      "cmd": "bash isbn_verifier.sh '3-598-21508-8'"
+    },
+    {
+      "name": "'invalid isbn check digit'",
+      "cmd": "bash isbn_verifier.sh '3-598-21508-9'"
+    },
+    {
+      "name": "'valid isbn number with a check digit of 10'",
+      "cmd": "bash isbn_verifier.sh '3-598-21507-X'"
+    },
+    {
+      "name": "'check digit is a character other than X'",
+      "cmd": "bash isbn_verifier.sh '3-598-21507-A'"
+    },
+    {
+      "name": "'invalid character in isbn'",
+      "cmd": "bash isbn_verifier.sh '3-598-P1581-X'"
+    },
+    {
+      "name": "'X is only valid as a check digit'",
+      "cmd": "bash isbn_verifier.sh '3-598-2X507-9'"
+    },
+    {
+      "name": "'valid isbn without separating dashes'",
+      "cmd": "bash isbn_verifier.sh '3598215088'"
+    },
+    {
+      "name": "'isbn without separating dashes and X as check digit'",
+      "cmd": "bash isbn_verifier.sh '359821507X'"
+    },
+    {
+      "name": "'isbn without check digit and dashes'",
+      "cmd": "bash isbn_verifier.sh '359821507'"
+    },
+    {
+      "name": "'too long isbn and no dashes'",
+      "cmd": "bash isbn_verifier.sh '3598215078X'"
+    },
+    {
+      "name": "'too short isbn'",
+      "cmd": "bash isbn_verifier.sh '00'"
+    },
+    {
+      "name": "'isbn without check digit'",
+      "cmd": "bash isbn_verifier.sh '3-598-21507'"
+    },
+    {
+      "name": "'check digit of X should not be used for 0'",
+      "cmd": "bash isbn_verifier.sh '3-598-21515-X'"
+    },
+    {
+      "name": "'empty isbn'",
+      "cmd": "bash isbn_verifier.sh ''"
+    },
+    {
+      "name": "'input is 9 characters'",
+      "cmd": "bash isbn_verifier.sh '134456729'"
+    },
+    {
+      "name": "'invalid characters are not ignored'",
+      "cmd": "bash isbn_verifier.sh '3132P34035'"
+    },
+    {
+      "name": "'input is too long but contains a valid isbn'",
+      "cmd": "bash isbn_verifier.sh '98245726788'"
+    }
+  ]
+}

--- a/exercises/isogram/.meta/config.json
+++ b/exercises/isogram/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "isogram.sh"
+  ],
+  "tests": [
+    {
+      "name": "'empty string'",
+      "cmd": "bash isogram.sh ''"
+    },
+    {
+      "name": "'isogram with only lower case characters'",
+      "cmd": "bash isogram.sh 'isogram'"
+    },
+    {
+      "name": "'word with one duplicated character'",
+      "cmd": "bash isogram.sh 'eleven'"
+    },
+    {
+      "name": "'word with one duplicated character from the end of the alphabet'",
+      "cmd": "bash isogram.sh 'zzyzx'"
+    },
+    {
+      "name": "'longest reported english isogram'",
+      "cmd": "bash isogram.sh 'subdermatoglyphic'"
+    },
+    {
+      "name": "'word with duplicated character in mixed case'",
+      "cmd": "bash isogram.sh 'Alphabet'"
+    },
+    {
+      "name": "'hypothetical isogrammic word with hyphen'",
+      "cmd": "bash isogram.sh 'thumbscrew-japingly'"
+    },
+    {
+      "name": "'isogram with duplicated hyphen'",
+      "cmd": "bash isogram.sh 'six-year-old'"
+    },
+    {
+      "name": "'hypothetical word with duplicated character following hyphen'",
+      "cmd": "bash isogram.sh 'thumbscrew-jappingly'"
+    },
+    {
+      "name": "'made-up name that is an isogram'",
+      "cmd": "bash isogram.sh 'Emily Jung Schwartzkopf'"
+    },
+    {
+      "name": "'duplicated character in the middle'",
+      "cmd": "bash isogram.sh 'accentor'"
+    },
+    {
+      "name": "'word with duplicated character in mixed case, lowercase first'",
+      "cmd": "bash isogram.sh 'alphAbet'"
+    },
+    {
+      "name": "'same first and last characters'",
+      "cmd": "bash isogram.sh 'angola'"
+    }
+  ]
+}

--- a/exercises/isogram/.meta/config.json
+++ b/exercises/isogram/.meta/config.json
@@ -4,55 +4,55 @@
   ],
   "tests": [
     {
-      "name": "'empty string'",
+      "name": "empty string",
       "cmd": "bash isogram.sh ''"
     },
     {
-      "name": "'isogram with only lower case characters'",
+      "name": "isogram with only lower case characters",
       "cmd": "bash isogram.sh 'isogram'"
     },
     {
-      "name": "'word with one duplicated character'",
+      "name": "word with one duplicated character",
       "cmd": "bash isogram.sh 'eleven'"
     },
     {
-      "name": "'word with one duplicated character from the end of the alphabet'",
+      "name": "word with one duplicated character from the end of the alphabet",
       "cmd": "bash isogram.sh 'zzyzx'"
     },
     {
-      "name": "'longest reported english isogram'",
+      "name": "longest reported english isogram",
       "cmd": "bash isogram.sh 'subdermatoglyphic'"
     },
     {
-      "name": "'word with duplicated character in mixed case'",
+      "name": "word with duplicated character in mixed case",
       "cmd": "bash isogram.sh 'Alphabet'"
     },
     {
-      "name": "'hypothetical isogrammic word with hyphen'",
+      "name": "hypothetical isogrammic word with hyphen",
       "cmd": "bash isogram.sh 'thumbscrew-japingly'"
     },
     {
-      "name": "'isogram with duplicated hyphen'",
+      "name": "isogram with duplicated hyphen",
       "cmd": "bash isogram.sh 'six-year-old'"
     },
     {
-      "name": "'hypothetical word with duplicated character following hyphen'",
+      "name": "hypothetical word with duplicated character following hyphen",
       "cmd": "bash isogram.sh 'thumbscrew-jappingly'"
     },
     {
-      "name": "'made-up name that is an isogram'",
+      "name": "made-up name that is an isogram",
       "cmd": "bash isogram.sh 'Emily Jung Schwartzkopf'"
     },
     {
-      "name": "'duplicated character in the middle'",
+      "name": "duplicated character in the middle",
       "cmd": "bash isogram.sh 'accentor'"
     },
     {
-      "name": "'word with duplicated character in mixed case, lowercase first'",
+      "name": "word with duplicated character in mixed case, lowercase first",
       "cmd": "bash isogram.sh 'alphAbet'"
     },
     {
-      "name": "'same first and last characters'",
+      "name": "same first and last characters",
       "cmd": "bash isogram.sh 'angola'"
     }
   ]

--- a/exercises/kindergarten-garden/.meta/config.json
+++ b/exercises/kindergarten-garden/.meta/config.json
@@ -1,0 +1,43 @@
+{
+  "solution_files": [
+    "kindergarten_garden.sh"
+  ],
+  "tests": [
+    {
+      "name": "garden with single student",
+      "cmd": "bash kindergarten_garden.sh $'RC\\nGG' \"Alice\""
+    },
+    {
+      "name": "different garden with single student",
+      "cmd": "bash kindergarten_garden.sh $'VC\\nRC' \"Alice\""
+    },
+    {
+      "name": "garden with two students",
+      "cmd": "bash kindergarten_garden.sh $'VVCG\\nVVRC' \"Bob\""
+    },
+    {
+      "name": "three students, second student's garden",
+      "cmd": "bash kindergarten_garden.sh $'VVCCGG\\nVVCCGG' \"Bob\""
+    },
+    {
+      "name": "three students, third student's garden",
+      "cmd": "bash kindergarten_garden.sh $'VVCCGG\\nVVCCGG' \"Charlie\""
+    },
+    {
+      "name": "first student's garden",
+      "cmd": "bash kindergarten_garden.sh $'VRCGVVRVCGGCCGVRGCVCGCGV\\nVRCCCGCRRGVCGCRVVCVGCGCV' \"Alice\""
+    },
+    {
+      "name": "second student's garden",
+      "cmd": "bash kindergarten_garden.sh $'VRCGVVRVCGGCCGVRGCVCGCGV\\nVRCCCGCRRGVCGCRVVCVGCGCV' \"Bob\""
+    },
+    {
+      "name": "second to last student's garden",
+      "cmd": "bash kindergarten_garden.sh $'VRCGVVRVCGGCCGVRGCVCGCGV\\nVRCCCGCRRGVCGCRVVCVGCGCV' \"Kincaid\""
+    },
+    {
+      "name": "last student's garden",
+      "cmd": "bash kindergarten_garden.sh $'VRCGVVRVCGGCCGVRGCVCGCGV\\nVRCCCGCRRGVCGCRVVCVGCGCV' \"Larry\""
+    }
+  ]
+}

--- a/exercises/knapsack/.meta/config.json
+++ b/exercises/knapsack/.meta/config.json
@@ -1,0 +1,39 @@
+{
+  "solution_files": [
+    "knapsack.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"error: no arguments\"",
+      "cmd": "bash knapsack.sh"
+    },
+    {
+      "name": "\"no items\"",
+      "cmd": "bash knapsack.sh 100"
+    },
+    {
+      "name": "\"one item: too heavy\"",
+      "cmd": "bash knapsack.sh 10 100:1"
+    },
+    {
+      "name": "\"five items (cannot be greedy by weight)\"",
+      "cmd": "bash knapsack.sh 10 2:5 2:5 2:5 2:5 10:21"
+    },
+    {
+      "name": "\"five items (cannot be greedy by value)\"",
+      "cmd": "bash knapsack.sh 10 2:20 2:20 2:20 2:20 10:50"
+    },
+    {
+      "name": "\"example knapsack\"",
+      "cmd": "bash knapsack.sh 10 5:10 4:40 6:30 4:50"
+    },
+    {
+      "name": "\"8 items\"",
+      "cmd": "bash knapsack.sh 104 25:350 35:400 45:450 5:20 25:70 3:8 2:5 2:5"
+    },
+    {
+      "name": "\"15 items\"",
+      "cmd": "bash knapsack.sh 750 70:135 73:139 77:149 80:150 82:156 87:163 90:173 94:184 98:192 106:201 110:210 113:214 115:221 118:229 120:240"
+    }
+  ]
+}

--- a/exercises/knapsack/.meta/config.json
+++ b/exercises/knapsack/.meta/config.json
@@ -4,35 +4,35 @@
   ],
   "tests": [
     {
-      "name": "\"error: no arguments\"",
+      "name": "error: no arguments",
       "cmd": "bash knapsack.sh"
     },
     {
-      "name": "\"no items\"",
+      "name": "no items",
       "cmd": "bash knapsack.sh 100"
     },
     {
-      "name": "\"one item: too heavy\"",
+      "name": "one item: too heavy",
       "cmd": "bash knapsack.sh 10 100:1"
     },
     {
-      "name": "\"five items (cannot be greedy by weight)\"",
+      "name": "five items (cannot be greedy by weight)",
       "cmd": "bash knapsack.sh 10 2:5 2:5 2:5 2:5 10:21"
     },
     {
-      "name": "\"five items (cannot be greedy by value)\"",
+      "name": "five items (cannot be greedy by value)",
       "cmd": "bash knapsack.sh 10 2:20 2:20 2:20 2:20 10:50"
     },
     {
-      "name": "\"example knapsack\"",
+      "name": "example knapsack",
       "cmd": "bash knapsack.sh 10 5:10 4:40 6:30 4:50"
     },
     {
-      "name": "\"8 items\"",
+      "name": "8 items",
       "cmd": "bash knapsack.sh 104 25:350 35:400 45:450 5:20 25:70 3:8 2:5 2:5"
     },
     {
-      "name": "\"15 items\"",
+      "name": "15 items",
       "cmd": "bash knapsack.sh 750 70:135 73:139 77:149 80:150 82:156 87:163 90:173 94:184 98:192 106:201 110:210 113:214 115:221 118:229 120:240"
     }
   ]

--- a/exercises/largest-series-product/.meta/config.json
+++ b/exercises/largest-series-product/.meta/config.json
@@ -1,0 +1,67 @@
+{
+  "solution_files": [
+    "largest_series_product.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"finds the largest product if span equals length\"",
+      "cmd": "bash largest_series_product.sh 29 2"
+    },
+    {
+      "name": "\"can find the largest product of 2 with numbers in order\"",
+      "cmd": "bash largest_series_product.sh 0123456789 2"
+    },
+    {
+      "name": "\"can find the largest product of 2\"",
+      "cmd": "bash largest_series_product.sh 576802143 2"
+    },
+    {
+      "name": "\"can find the largest product of 3 with numbers in order\"",
+      "cmd": "bash largest_series_product.sh 0123456789 3"
+    },
+    {
+      "name": "\"can find the largest product of 3\"",
+      "cmd": "bash largest_series_product.sh 1027839564 3"
+    },
+    {
+      "name": "\"can find the largest product of 5 with numbers in order\"",
+      "cmd": "bash largest_series_product.sh 0123456789 5"
+    },
+    {
+      "name": "\"can get the largest product of a big number\"",
+      "cmd": "bash largest_series_product.sh 73167176531330624919225119674426574742355349194934 6"
+    },
+    {
+      "name": "\"reports zero if the only digits are zero\"",
+      "cmd": "bash largest_series_product.sh 0000 2"
+    },
+    {
+      "name": "\"reports zero if all spans include zero\"",
+      "cmd": "bash largest_series_product.sh 99099 3"
+    },
+    {
+      "name": "\"reports 1 for empty string and empty product (0 span)\"",
+      "cmd": "bash largest_series_product.sh 0"
+    },
+    {
+      "name": "\"reports 1 for nonempty string and empty product (0 span)\"",
+      "cmd": "bash largest_series_product.sh 123 0"
+    },
+    {
+      "name": "\"rejects span longer than string length\"",
+      "cmd": "bash largest_series_product.sh 123 4"
+    },
+    {
+      "name": "\"rejects empty string and nonzero span\"",
+      "cmd": "bash largest_series_product.sh \"\" 1"
+    },
+    {
+      "name": "\"rejects invalid character in digits\"",
+      "cmd": "bash largest_series_product.sh 1234a5 2"
+    },
+    {
+      "name": "\"rejects negative span\"",
+      "cmd": "bash largest_series_product.sh 12345 -1"
+    }
+  ]
+}

--- a/exercises/largest-series-product/.meta/config.json
+++ b/exercises/largest-series-product/.meta/config.json
@@ -4,63 +4,63 @@
   ],
   "tests": [
     {
-      "name": "\"finds the largest product if span equals length\"",
+      "name": "finds the largest product if span equals length",
       "cmd": "bash largest_series_product.sh 29 2"
     },
     {
-      "name": "\"can find the largest product of 2 with numbers in order\"",
+      "name": "can find the largest product of 2 with numbers in order",
       "cmd": "bash largest_series_product.sh 0123456789 2"
     },
     {
-      "name": "\"can find the largest product of 2\"",
+      "name": "can find the largest product of 2",
       "cmd": "bash largest_series_product.sh 576802143 2"
     },
     {
-      "name": "\"can find the largest product of 3 with numbers in order\"",
+      "name": "can find the largest product of 3 with numbers in order",
       "cmd": "bash largest_series_product.sh 0123456789 3"
     },
     {
-      "name": "\"can find the largest product of 3\"",
+      "name": "can find the largest product of 3",
       "cmd": "bash largest_series_product.sh 1027839564 3"
     },
     {
-      "name": "\"can find the largest product of 5 with numbers in order\"",
+      "name": "can find the largest product of 5 with numbers in order",
       "cmd": "bash largest_series_product.sh 0123456789 5"
     },
     {
-      "name": "\"can get the largest product of a big number\"",
+      "name": "can get the largest product of a big number",
       "cmd": "bash largest_series_product.sh 73167176531330624919225119674426574742355349194934 6"
     },
     {
-      "name": "\"reports zero if the only digits are zero\"",
+      "name": "reports zero if the only digits are zero",
       "cmd": "bash largest_series_product.sh 0000 2"
     },
     {
-      "name": "\"reports zero if all spans include zero\"",
+      "name": "reports zero if all spans include zero",
       "cmd": "bash largest_series_product.sh 99099 3"
     },
     {
-      "name": "\"reports 1 for empty string and empty product (0 span)\"",
+      "name": "reports 1 for empty string and empty product (0 span)",
       "cmd": "bash largest_series_product.sh 0"
     },
     {
-      "name": "\"reports 1 for nonempty string and empty product (0 span)\"",
+      "name": "reports 1 for nonempty string and empty product (0 span)",
       "cmd": "bash largest_series_product.sh 123 0"
     },
     {
-      "name": "\"rejects span longer than string length\"",
+      "name": "rejects span longer than string length",
       "cmd": "bash largest_series_product.sh 123 4"
     },
     {
-      "name": "\"rejects empty string and nonzero span\"",
+      "name": "rejects empty string and nonzero span",
       "cmd": "bash largest_series_product.sh \"\" 1"
     },
     {
-      "name": "\"rejects invalid character in digits\"",
+      "name": "rejects invalid character in digits",
       "cmd": "bash largest_series_product.sh 1234a5 2"
     },
     {
-      "name": "\"rejects negative span\"",
+      "name": "rejects negative span",
       "cmd": "bash largest_series_product.sh 12345 -1"
     }
   ]

--- a/exercises/leap/.meta/config.json
+++ b/exercises/leap/.meta/config.json
@@ -4,55 +4,55 @@
   ],
   "tests": [
     {
-      "name": "'year not divisible by 4: common year'",
+      "name": "year not divisible by 4: common year",
       "cmd": "bash leap.sh 2015"
     },
     {
-      "name": "'year divisible by 2, not divisible by 4 in common year'",
+      "name": "year divisible by 2, not divisible by 4 in common year",
       "cmd": "bash leap.sh 1970"
     },
     {
-      "name": "'year divisible by 4, not divisible by 100: leap year'",
+      "name": "year divisible by 4, not divisible by 100: leap year",
       "cmd": "bash leap.sh 1996"
     },
     {
-      "name": "'year divisible by 4 and 5 is still a leap year'",
+      "name": "year divisible by 4 and 5 is still a leap year",
       "cmd": "bash leap.sh 1960"
     },
     {
-      "name": "'year divisible by 100, not divisible by 400: common year'",
+      "name": "year divisible by 100, not divisible by 400: common year",
       "cmd": "bash leap.sh 2100"
     },
     {
-      "name": "'year divisible by 100 but not by 3 is still not a leap year'",
+      "name": "year divisible by 100 but not by 3 is still not a leap year",
       "cmd": "bash leap.sh 1900"
     },
     {
-      "name": "'year divisible by 400: leap year'",
+      "name": "year divisible by 400: leap year",
       "cmd": "bash leap.sh 2000"
     },
     {
-      "name": "'year divisible by 400 but not by 125 is still a leap year'",
+      "name": "year divisible by 400 but not by 125 is still a leap year",
       "cmd": "bash leap.sh 2400"
     },
     {
-      "name": "'year divisible by 200, not divisible by 400 in common year'",
+      "name": "year divisible by 200, not divisible by 400 in common year",
       "cmd": "bash leap.sh 1800"
     },
     {
-      "name": "'No input should return an error'",
+      "name": "No input should return an error",
       "cmd": "bash leap.sh"
     },
     {
-      "name": "'Too many arguments should return an error'",
+      "name": "Too many arguments should return an error",
       "cmd": "bash leap.sh 2016 4562 4566"
     },
     {
-      "name": "'Float number input should return an error'",
+      "name": "Float number input should return an error",
       "cmd": "bash leap.sh 2016.54"
     },
     {
-      "name": "'Alpha input should return an error'",
+      "name": "Alpha input should return an error",
       "cmd": "bash leap.sh 'abcd'"
     }
   ]

--- a/exercises/leap/.meta/config.json
+++ b/exercises/leap/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "leap.sh"
+  ],
+  "tests": [
+    {
+      "name": "'year not divisible by 4: common year'",
+      "cmd": "bash leap.sh 2015"
+    },
+    {
+      "name": "'year divisible by 2, not divisible by 4 in common year'",
+      "cmd": "bash leap.sh 1970"
+    },
+    {
+      "name": "'year divisible by 4, not divisible by 100: leap year'",
+      "cmd": "bash leap.sh 1996"
+    },
+    {
+      "name": "'year divisible by 4 and 5 is still a leap year'",
+      "cmd": "bash leap.sh 1960"
+    },
+    {
+      "name": "'year divisible by 100, not divisible by 400: common year'",
+      "cmd": "bash leap.sh 2100"
+    },
+    {
+      "name": "'year divisible by 100 but not by 3 is still not a leap year'",
+      "cmd": "bash leap.sh 1900"
+    },
+    {
+      "name": "'year divisible by 400: leap year'",
+      "cmd": "bash leap.sh 2000"
+    },
+    {
+      "name": "'year divisible by 400 but not by 125 is still a leap year'",
+      "cmd": "bash leap.sh 2400"
+    },
+    {
+      "name": "'year divisible by 200, not divisible by 400 in common year'",
+      "cmd": "bash leap.sh 1800"
+    },
+    {
+      "name": "'No input should return an error'",
+      "cmd": "bash leap.sh"
+    },
+    {
+      "name": "'Too many arguments should return an error'",
+      "cmd": "bash leap.sh 2016 4562 4566"
+    },
+    {
+      "name": "'Float number input should return an error'",
+      "cmd": "bash leap.sh 2016.54"
+    },
+    {
+      "name": "'Alpha input should return an error'",
+      "cmd": "bash leap.sh 'abcd'"
+    }
+  ]
+}

--- a/exercises/luhn/.meta/config.json
+++ b/exercises/luhn/.meta/config.json
@@ -4,71 +4,71 @@
   ],
   "tests": [
     {
-      "name": "\"single digit strings can not be valid\"",
+      "name": "single digit strings can not be valid",
       "cmd": "bash luhn.sh \"1\""
     },
     {
-      "name": "\"a single zero is invalid\"",
+      "name": "a single zero is invalid",
       "cmd": "bash luhn.sh \"0\""
     },
     {
-      "name": "\"a simple valid SIN that remains valid if reversed\"",
+      "name": "a simple valid SIN that remains valid if reversed",
       "cmd": "bash luhn.sh \"059\""
     },
     {
-      "name": "\"a simple valid SIN that becomes invalid if reversed\"",
+      "name": "a simple valid SIN that becomes invalid if reversed",
       "cmd": "bash luhn.sh \"59\""
     },
     {
-      "name": "\"a valid Canadian SIN\"",
+      "name": "a valid Canadian SIN",
       "cmd": "bash luhn.sh \"055 444 285\""
     },
     {
-      "name": "\"invalid Canadian SIN\"",
+      "name": "invalid Canadian SIN",
       "cmd": "bash luhn.sh \"055 444 286\""
     },
     {
-      "name": "\"invalid credit card\"",
+      "name": "invalid credit card",
       "cmd": "bash luhn.sh \"8273 1232 7352 0569\""
     },
     {
-      "name": "\"valid number with an even number of digits\"",
+      "name": "valid number with an even number of digits",
       "cmd": "bash luhn.sh \"095 245 88\""
     },
     {
-      "name": "\"valid number with an odd number of spaces\"",
+      "name": "valid number with an odd number of spaces",
       "cmd": "bash luhn.sh \"234 567 891 234\""
     },
     {
-      "name": "\"valid strings with a non-digit included become invalid\"",
+      "name": "valid strings with a non-digit included become invalid",
       "cmd": "bash luhn.sh \"055a 444 285\""
     },
     {
-      "name": "\"valid strings with punctuation included become invalid\"",
+      "name": "valid strings with punctuation included become invalid",
       "cmd": "bash luhn.sh \"055-444-285\""
     },
     {
-      "name": "\"valid strings with symbols included become invalid\"",
+      "name": "valid strings with symbols included become invalid",
       "cmd": "bash luhn.sh \"055Â£ 444$ 285\""
     },
     {
-      "name": "\"single zero with space is invalid\"",
+      "name": "single zero with space is invalid",
       "cmd": "bash luhn.sh \" 0\""
     },
     {
-      "name": "\"more than a single zero is valid\"",
+      "name": "more than a single zero is valid",
       "cmd": "bash luhn.sh \"0000 0\""
     },
     {
-      "name": "\"input digit 9 is correctly converted to output digit 9\"",
+      "name": "input digit 9 is correctly converted to output digit 9",
       "cmd": "bash luhn.sh \"091\""
     },
     {
-      "name": "\"using ascii value for non-doubled non-digit isn't allowed\"",
+      "name": "using ascii value for non-doubled non-digit isn't allowed",
       "cmd": "bash luhn.sh \"055b 444 285\""
     },
     {
-      "name": "\"using ascii value for doubled non-digit isn't allowed\"",
+      "name": "using ascii value for doubled non-digit isn't allowed",
       "cmd": "bash luhn.sh \":9\""
     }
   ]

--- a/exercises/luhn/.meta/config.json
+++ b/exercises/luhn/.meta/config.json
@@ -1,0 +1,75 @@
+{
+  "solution_files": [
+    "luhn.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"single digit strings can not be valid\"",
+      "cmd": "bash luhn.sh \"1\""
+    },
+    {
+      "name": "\"a single zero is invalid\"",
+      "cmd": "bash luhn.sh \"0\""
+    },
+    {
+      "name": "\"a simple valid SIN that remains valid if reversed\"",
+      "cmd": "bash luhn.sh \"059\""
+    },
+    {
+      "name": "\"a simple valid SIN that becomes invalid if reversed\"",
+      "cmd": "bash luhn.sh \"59\""
+    },
+    {
+      "name": "\"a valid Canadian SIN\"",
+      "cmd": "bash luhn.sh \"055 444 285\""
+    },
+    {
+      "name": "\"invalid Canadian SIN\"",
+      "cmd": "bash luhn.sh \"055 444 286\""
+    },
+    {
+      "name": "\"invalid credit card\"",
+      "cmd": "bash luhn.sh \"8273 1232 7352 0569\""
+    },
+    {
+      "name": "\"valid number with an even number of digits\"",
+      "cmd": "bash luhn.sh \"095 245 88\""
+    },
+    {
+      "name": "\"valid number with an odd number of spaces\"",
+      "cmd": "bash luhn.sh \"234 567 891 234\""
+    },
+    {
+      "name": "\"valid strings with a non-digit included become invalid\"",
+      "cmd": "bash luhn.sh \"055a 444 285\""
+    },
+    {
+      "name": "\"valid strings with punctuation included become invalid\"",
+      "cmd": "bash luhn.sh \"055-444-285\""
+    },
+    {
+      "name": "\"valid strings with symbols included become invalid\"",
+      "cmd": "bash luhn.sh \"055Â£ 444$ 285\""
+    },
+    {
+      "name": "\"single zero with space is invalid\"",
+      "cmd": "bash luhn.sh \" 0\""
+    },
+    {
+      "name": "\"more than a single zero is valid\"",
+      "cmd": "bash luhn.sh \"0000 0\""
+    },
+    {
+      "name": "\"input digit 9 is correctly converted to output digit 9\"",
+      "cmd": "bash luhn.sh \"091\""
+    },
+    {
+      "name": "\"using ascii value for non-doubled non-digit isn't allowed\"",
+      "cmd": "bash luhn.sh \"055b 444 285\""
+    },
+    {
+      "name": "\"using ascii value for doubled non-digit isn't allowed\"",
+      "cmd": "bash luhn.sh \":9\""
+    }
+  ]
+}

--- a/exercises/markdown/.meta/config.json
+++ b/exercises/markdown/.meta/config.json
@@ -1,0 +1,63 @@
+{
+  "solution_files": [
+    "markdown.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"parses normal text as a paragraph\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"parsing italics\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"parsing multiple italics\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"parsing bold text\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"mixed normal, italics and bold text\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"with h1 header level\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"with h2 header level\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"with h6 header level\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"unordered lists\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"With a little bit of everything\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"with markdown symbols in the header text that should not be interpreted\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"with markdown symbols in the list item text that should not be interpreted\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"with markdown symbols in the paragraph text that should not be interpreted\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    },
+    {
+      "name": "\"unordered lists close properly with preceding and following lines\"",
+      "cmd": "bash markdown.sh \"$MD_FILE\""
+    }
+  ]
+}

--- a/exercises/markdown/.meta/config.json
+++ b/exercises/markdown/.meta/config.json
@@ -4,59 +4,59 @@
   ],
   "tests": [
     {
-      "name": "\"parses normal text as a paragraph\"",
+      "name": "parses normal text as a paragraph",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"parsing italics\"",
+      "name": "parsing italics",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"parsing multiple italics\"",
+      "name": "parsing multiple italics",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"parsing bold text\"",
+      "name": "parsing bold text",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"mixed normal, italics and bold text\"",
+      "name": "mixed normal, italics and bold text",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"with h1 header level\"",
+      "name": "with h1 header level",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"with h2 header level\"",
+      "name": "with h2 header level",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"with h6 header level\"",
+      "name": "with h6 header level",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"unordered lists\"",
+      "name": "unordered lists",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"With a little bit of everything\"",
+      "name": "With a little bit of everything",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"with markdown symbols in the header text that should not be interpreted\"",
+      "name": "with markdown symbols in the header text that should not be interpreted",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"with markdown symbols in the list item text that should not be interpreted\"",
+      "name": "with markdown symbols in the list item text that should not be interpreted",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"with markdown symbols in the paragraph text that should not be interpreted\"",
+      "name": "with markdown symbols in the paragraph text that should not be interpreted",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     },
     {
-      "name": "\"unordered lists close properly with preceding and following lines\"",
+      "name": "unordered lists close properly with preceding and following lines",
       "cmd": "bash markdown.sh \"$MD_FILE\""
     }
   ]

--- a/exercises/matching-brackets/.meta/config.json
+++ b/exercises/matching-brackets/.meta/config.json
@@ -4,71 +4,71 @@
   ],
   "tests": [
     {
-      "name": "\"paired square brackets\"",
+      "name": "paired square brackets",
       "cmd": "bash matching_brackets.sh \"[]\""
     },
     {
-      "name": "\"empty string\"",
+      "name": "empty string",
       "cmd": "bash matching_brackets.sh \"\""
     },
     {
-      "name": "\"unpaired brackets\"",
+      "name": "unpaired brackets",
       "cmd": "bash matching_brackets.sh \"[[\""
     },
     {
-      "name": "\"wrong ordered brackets\"",
+      "name": "wrong ordered brackets",
       "cmd": "bash matching_brackets.sh \"}{\""
     },
     {
-      "name": "\"wrong closing bracket\"",
+      "name": "wrong closing bracket",
       "cmd": "bash matching_brackets.sh \"{]\""
     },
     {
-      "name": "\"paired with whitespace\"",
+      "name": "paired with whitespace",
       "cmd": "bash matching_brackets.sh \"{ }\""
     },
     {
-      "name": "\"partially paired brackets\"",
+      "name": "partially paired brackets",
       "cmd": "bash matching_brackets.sh \"{[])\""
     },
     {
-      "name": "\"simple nested brackets\"",
+      "name": "simple nested brackets",
       "cmd": "bash matching_brackets.sh \"{[]}\""
     },
     {
-      "name": "\"several paired brackets\"",
+      "name": "several paired brackets",
       "cmd": "bash matching_brackets.sh \"{}[]\""
     },
     {
-      "name": "\"paired and nested brackets\"",
+      "name": "paired and nested brackets",
       "cmd": "bash matching_brackets.sh \"([{}({}[])])\""
     },
     {
-      "name": "\"unopened closing brackets\"",
+      "name": "unopened closing brackets",
       "cmd": "bash matching_brackets.sh \"{[)][]}\""
     },
     {
-      "name": "\"unpaired and nested brackets\"",
+      "name": "unpaired and nested brackets",
       "cmd": "bash matching_brackets.sh \"([{])\""
     },
     {
-      "name": "\"paired and wrong nested brackets\"",
+      "name": "paired and wrong nested brackets",
       "cmd": "bash matching_brackets.sh \"[({]})\""
     },
     {
-      "name": "\"paired and incomplete brackets\"",
+      "name": "paired and incomplete brackets",
       "cmd": "bash matching_brackets.sh \"{}[\""
     },
     {
-      "name": "\"too many closing brackets\"",
+      "name": "too many closing brackets",
       "cmd": "bash matching_brackets.sh \"[]]\""
     },
     {
-      "name": "\"math expression\"",
+      "name": "math expression",
       "cmd": "bash matching_brackets.sh \"(((185 + 223.85) * 15) - 543)/2\""
     },
     {
-      "name": "\"complex latex expression\"",
+      "name": "complex latex expression",
       "cmd": "bash matching_brackets.sh \"\\\\left(\\\\begin{array}{cc} \\\\frac{1}{3} & x\\\\\\\\ \\\\mathrm{e}^{x} &... x^2 \\\\end{array}\\\\right)\""
     }
   ]

--- a/exercises/matching-brackets/.meta/config.json
+++ b/exercises/matching-brackets/.meta/config.json
@@ -1,0 +1,75 @@
+{
+  "solution_files": [
+    "matching_brackets.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"paired square brackets\"",
+      "cmd": "bash matching_brackets.sh \"[]\""
+    },
+    {
+      "name": "\"empty string\"",
+      "cmd": "bash matching_brackets.sh \"\""
+    },
+    {
+      "name": "\"unpaired brackets\"",
+      "cmd": "bash matching_brackets.sh \"[[\""
+    },
+    {
+      "name": "\"wrong ordered brackets\"",
+      "cmd": "bash matching_brackets.sh \"}{\""
+    },
+    {
+      "name": "\"wrong closing bracket\"",
+      "cmd": "bash matching_brackets.sh \"{]\""
+    },
+    {
+      "name": "\"paired with whitespace\"",
+      "cmd": "bash matching_brackets.sh \"{ }\""
+    },
+    {
+      "name": "\"partially paired brackets\"",
+      "cmd": "bash matching_brackets.sh \"{[])\""
+    },
+    {
+      "name": "\"simple nested brackets\"",
+      "cmd": "bash matching_brackets.sh \"{[]}\""
+    },
+    {
+      "name": "\"several paired brackets\"",
+      "cmd": "bash matching_brackets.sh \"{}[]\""
+    },
+    {
+      "name": "\"paired and nested brackets\"",
+      "cmd": "bash matching_brackets.sh \"([{}({}[])])\""
+    },
+    {
+      "name": "\"unopened closing brackets\"",
+      "cmd": "bash matching_brackets.sh \"{[)][]}\""
+    },
+    {
+      "name": "\"unpaired and nested brackets\"",
+      "cmd": "bash matching_brackets.sh \"([{])\""
+    },
+    {
+      "name": "\"paired and wrong nested brackets\"",
+      "cmd": "bash matching_brackets.sh \"[({]})\""
+    },
+    {
+      "name": "\"paired and incomplete brackets\"",
+      "cmd": "bash matching_brackets.sh \"{}[\""
+    },
+    {
+      "name": "\"too many closing brackets\"",
+      "cmd": "bash matching_brackets.sh \"[]]\""
+    },
+    {
+      "name": "\"math expression\"",
+      "cmd": "bash matching_brackets.sh \"(((185 + 223.85) * 15) - 543)/2\""
+    },
+    {
+      "name": "\"complex latex expression\"",
+      "cmd": "bash matching_brackets.sh \"\\\\left(\\\\begin{array}{cc} \\\\frac{1}{3} & x\\\\\\\\ \\\\mathrm{e}^{x} &... x^2 \\\\end{array}\\\\right)\""
+    }
+  ]
+}

--- a/exercises/meetup/.meta/config.json
+++ b/exercises/meetup/.meta/config.json
@@ -1,0 +1,387 @@
+{
+  "solution_files": [
+    "meetup.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"monteenth of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 teenth Monday"
+    },
+    {
+      "name": "\"monteenth of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 teenth Monday"
+    },
+    {
+      "name": "\"monteenth of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 teenth Monday"
+    },
+    {
+      "name": "\"tuesteenth of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 teenth Tuesday"
+    },
+    {
+      "name": "\"tuesteenth of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 teenth Tuesday"
+    },
+    {
+      "name": "\"tuesteenth of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 teenth Tuesday"
+    },
+    {
+      "name": "\"wednesteenth of January 2013\"",
+      "cmd": "bash meetup.sh 2013 1 teenth Wednesday"
+    },
+    {
+      "name": "\"wednesteenth of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 teenth Wednesday"
+    },
+    {
+      "name": "\"wednesteenth of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 teenth Wednesday"
+    },
+    {
+      "name": "\"thursteenth of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 teenth Thursday"
+    },
+    {
+      "name": "\"thursteenth of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 teenth Thursday"
+    },
+    {
+      "name": "\"thursteenth of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 teenth Thursday"
+    },
+    {
+      "name": "\"friteenth of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 teenth Friday"
+    },
+    {
+      "name": "\"friteenth of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 teenth Friday"
+    },
+    {
+      "name": "\"friteenth of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 teenth Friday"
+    },
+    {
+      "name": "\"saturteenth of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 teenth Saturday"
+    },
+    {
+      "name": "\"saturteenth of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 teenth Saturday"
+    },
+    {
+      "name": "\"saturteenth of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 teenth Saturday"
+    },
+    {
+      "name": "\"sunteenth of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 teenth Sunday"
+    },
+    {
+      "name": "\"sunteenth of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 teenth Sunday"
+    },
+    {
+      "name": "\"sunteenth of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 teenth Sunday"
+    },
+    {
+      "name": "\"first Monday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 first Monday"
+    },
+    {
+      "name": "\"first Monday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 first Monday"
+    },
+    {
+      "name": "\"first Tuesday of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 first Tuesday"
+    },
+    {
+      "name": "\"first Tuesday of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 first Tuesday"
+    },
+    {
+      "name": "\"first Wednesday of July 2013\"",
+      "cmd": "bash meetup.sh 2013 7 first Wednesday"
+    },
+    {
+      "name": "\"first Wednesday of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 first Wednesday"
+    },
+    {
+      "name": "\"first Thursday of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 first Thursday"
+    },
+    {
+      "name": "\"first Thursday of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 first Thursday"
+    },
+    {
+      "name": "\"first Friday of November 2013\"",
+      "cmd": "bash meetup.sh 2013 11 first Friday"
+    },
+    {
+      "name": "\"first Friday of December 2013\"",
+      "cmd": "bash meetup.sh 2013 12 first Friday"
+    },
+    {
+      "name": "\"first Saturday of January 2013\"",
+      "cmd": "bash meetup.sh 2013 1 first Saturday"
+    },
+    {
+      "name": "\"first Saturday of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 first Saturday"
+    },
+    {
+      "name": "\"first Sunday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 first Sunday"
+    },
+    {
+      "name": "\"first Sunday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 first Sunday"
+    },
+    {
+      "name": "\"second Monday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 second Monday"
+    },
+    {
+      "name": "\"second Monday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 second Monday"
+    },
+    {
+      "name": "\"second Tuesday of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 second Tuesday"
+    },
+    {
+      "name": "\"second Tuesday of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 second Tuesday"
+    },
+    {
+      "name": "\"second Wednesday of July 2013\"",
+      "cmd": "bash meetup.sh 2013 7 second Wednesday"
+    },
+    {
+      "name": "\"second Wednesday of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 second Wednesday"
+    },
+    {
+      "name": "\"second Thursday of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 second Thursday"
+    },
+    {
+      "name": "\"second Thursday of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 second Thursday"
+    },
+    {
+      "name": "\"second Friday of November 2013\"",
+      "cmd": "bash meetup.sh 2013 11 second Friday"
+    },
+    {
+      "name": "\"second Friday of December 2013\"",
+      "cmd": "bash meetup.sh 2013 12 second Friday"
+    },
+    {
+      "name": "\"second Saturday of January 2013\"",
+      "cmd": "bash meetup.sh 2013 1 second Saturday"
+    },
+    {
+      "name": "\"second Saturday of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 second Saturday"
+    },
+    {
+      "name": "\"second Sunday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 second Sunday"
+    },
+    {
+      "name": "\"second Sunday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 second Sunday"
+    },
+    {
+      "name": "\"third Monday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 third Monday"
+    },
+    {
+      "name": "\"third Monday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 third Monday"
+    },
+    {
+      "name": "\"third Tuesday of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 third Tuesday"
+    },
+    {
+      "name": "\"third Tuesday of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 third Tuesday"
+    },
+    {
+      "name": "\"third Wednesday of July 2013\"",
+      "cmd": "bash meetup.sh 2013 7 third Wednesday"
+    },
+    {
+      "name": "\"third Wednesday of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 third Wednesday"
+    },
+    {
+      "name": "\"third Thursday of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 third Thursday"
+    },
+    {
+      "name": "\"third Thursday of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 third Thursday"
+    },
+    {
+      "name": "\"third Friday of November 2013\"",
+      "cmd": "bash meetup.sh 2013 11 third Friday"
+    },
+    {
+      "name": "\"third Friday of December 2013\"",
+      "cmd": "bash meetup.sh 2013 12 third Friday"
+    },
+    {
+      "name": "\"third Saturday of January 2013\"",
+      "cmd": "bash meetup.sh 2013 1 third Saturday"
+    },
+    {
+      "name": "\"third Saturday of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 third Saturday"
+    },
+    {
+      "name": "\"third Sunday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 third Sunday"
+    },
+    {
+      "name": "\"third Sunday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 third Sunday"
+    },
+    {
+      "name": "\"fourth Monday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 fourth Monday"
+    },
+    {
+      "name": "\"fourth Monday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 fourth Monday"
+    },
+    {
+      "name": "\"fourth Tuesday of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 fourth Tuesday"
+    },
+    {
+      "name": "\"fourth Tuesday of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 fourth Tuesday"
+    },
+    {
+      "name": "\"fourth Wednesday of July 2013\"",
+      "cmd": "bash meetup.sh 2013 7 fourth Wednesday"
+    },
+    {
+      "name": "\"fourth Wednesday of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 fourth Wednesday"
+    },
+    {
+      "name": "\"fourth Thursday of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 fourth Thursday"
+    },
+    {
+      "name": "\"fourth Thursday of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 fourth Thursday"
+    },
+    {
+      "name": "\"fourth Friday of November 2013\"",
+      "cmd": "bash meetup.sh 2013 11 fourth Friday"
+    },
+    {
+      "name": "\"fourth Friday of December 2013\"",
+      "cmd": "bash meetup.sh 2013 12 fourth Friday"
+    },
+    {
+      "name": "\"fourth Saturday of January 2013\"",
+      "cmd": "bash meetup.sh 2013 1 fourth Saturday"
+    },
+    {
+      "name": "\"fourth Saturday of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 fourth Saturday"
+    },
+    {
+      "name": "\"fourth Sunday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 fourth Sunday"
+    },
+    {
+      "name": "\"fourth Sunday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 fourth Sunday"
+    },
+    {
+      "name": "\"last Monday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 last Monday"
+    },
+    {
+      "name": "\"last Monday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 last Monday"
+    },
+    {
+      "name": "\"last Tuesday of May 2013\"",
+      "cmd": "bash meetup.sh 2013 5 last Tuesday"
+    },
+    {
+      "name": "\"last Tuesday of June 2013\"",
+      "cmd": "bash meetup.sh 2013 6 last Tuesday"
+    },
+    {
+      "name": "\"last Wednesday of July 2013\"",
+      "cmd": "bash meetup.sh 2013 7 last Wednesday"
+    },
+    {
+      "name": "\"last Wednesday of August 2013\"",
+      "cmd": "bash meetup.sh 2013 8 last Wednesday"
+    },
+    {
+      "name": "\"last Thursday of September 2013\"",
+      "cmd": "bash meetup.sh 2013 9 last Thursday"
+    },
+    {
+      "name": "\"last Thursday of October 2013\"",
+      "cmd": "bash meetup.sh 2013 10 last Thursday"
+    },
+    {
+      "name": "\"last Friday of November 2013\"",
+      "cmd": "bash meetup.sh 2013 11 last Friday"
+    },
+    {
+      "name": "\"last Friday of December 2013\"",
+      "cmd": "bash meetup.sh 2013 12 last Friday"
+    },
+    {
+      "name": "\"last Saturday of January 2013\"",
+      "cmd": "bash meetup.sh 2013 1 last Saturday"
+    },
+    {
+      "name": "\"last Saturday of February 2013\"",
+      "cmd": "bash meetup.sh 2013 2 last Saturday"
+    },
+    {
+      "name": "\"last Sunday of March 2013\"",
+      "cmd": "bash meetup.sh 2013 3 last Sunday"
+    },
+    {
+      "name": "\"last Sunday of April 2013\"",
+      "cmd": "bash meetup.sh 2013 4 last Sunday"
+    },
+    {
+      "name": "\"last Wednesday of February 2012\"",
+      "cmd": "bash meetup.sh 2012 2 last Wednesday"
+    },
+    {
+      "name": "\"last Wednesday of December 2014\"",
+      "cmd": "bash meetup.sh 2014 12 last Wednesday"
+    },
+    {
+      "name": "\"last Sunday of February 2015\"",
+      "cmd": "bash meetup.sh 2015 2 last Sunday"
+    },
+    {
+      "name": "\"first Friday of December 2012\"",
+      "cmd": "bash meetup.sh 2012 12 first Friday"
+    }
+  ]
+}

--- a/exercises/meetup/.meta/config.json
+++ b/exercises/meetup/.meta/config.json
@@ -4,383 +4,383 @@
   ],
   "tests": [
     {
-      "name": "\"monteenth of May 2013\"",
+      "name": "monteenth of May 2013",
       "cmd": "bash meetup.sh 2013 5 teenth Monday"
     },
     {
-      "name": "\"monteenth of August 2013\"",
+      "name": "monteenth of August 2013",
       "cmd": "bash meetup.sh 2013 8 teenth Monday"
     },
     {
-      "name": "\"monteenth of September 2013\"",
+      "name": "monteenth of September 2013",
       "cmd": "bash meetup.sh 2013 9 teenth Monday"
     },
     {
-      "name": "\"tuesteenth of March 2013\"",
+      "name": "tuesteenth of March 2013",
       "cmd": "bash meetup.sh 2013 3 teenth Tuesday"
     },
     {
-      "name": "\"tuesteenth of April 2013\"",
+      "name": "tuesteenth of April 2013",
       "cmd": "bash meetup.sh 2013 4 teenth Tuesday"
     },
     {
-      "name": "\"tuesteenth of August 2013\"",
+      "name": "tuesteenth of August 2013",
       "cmd": "bash meetup.sh 2013 8 teenth Tuesday"
     },
     {
-      "name": "\"wednesteenth of January 2013\"",
+      "name": "wednesteenth of January 2013",
       "cmd": "bash meetup.sh 2013 1 teenth Wednesday"
     },
     {
-      "name": "\"wednesteenth of February 2013\"",
+      "name": "wednesteenth of February 2013",
       "cmd": "bash meetup.sh 2013 2 teenth Wednesday"
     },
     {
-      "name": "\"wednesteenth of June 2013\"",
+      "name": "wednesteenth of June 2013",
       "cmd": "bash meetup.sh 2013 6 teenth Wednesday"
     },
     {
-      "name": "\"thursteenth of May 2013\"",
+      "name": "thursteenth of May 2013",
       "cmd": "bash meetup.sh 2013 5 teenth Thursday"
     },
     {
-      "name": "\"thursteenth of June 2013\"",
+      "name": "thursteenth of June 2013",
       "cmd": "bash meetup.sh 2013 6 teenth Thursday"
     },
     {
-      "name": "\"thursteenth of September 2013\"",
+      "name": "thursteenth of September 2013",
       "cmd": "bash meetup.sh 2013 9 teenth Thursday"
     },
     {
-      "name": "\"friteenth of April 2013\"",
+      "name": "friteenth of April 2013",
       "cmd": "bash meetup.sh 2013 4 teenth Friday"
     },
     {
-      "name": "\"friteenth of August 2013\"",
+      "name": "friteenth of August 2013",
       "cmd": "bash meetup.sh 2013 8 teenth Friday"
     },
     {
-      "name": "\"friteenth of September 2013\"",
+      "name": "friteenth of September 2013",
       "cmd": "bash meetup.sh 2013 9 teenth Friday"
     },
     {
-      "name": "\"saturteenth of February 2013\"",
+      "name": "saturteenth of February 2013",
       "cmd": "bash meetup.sh 2013 2 teenth Saturday"
     },
     {
-      "name": "\"saturteenth of April 2013\"",
+      "name": "saturteenth of April 2013",
       "cmd": "bash meetup.sh 2013 4 teenth Saturday"
     },
     {
-      "name": "\"saturteenth of October 2013\"",
+      "name": "saturteenth of October 2013",
       "cmd": "bash meetup.sh 2013 10 teenth Saturday"
     },
     {
-      "name": "\"sunteenth of May 2013\"",
+      "name": "sunteenth of May 2013",
       "cmd": "bash meetup.sh 2013 5 teenth Sunday"
     },
     {
-      "name": "\"sunteenth of June 2013\"",
+      "name": "sunteenth of June 2013",
       "cmd": "bash meetup.sh 2013 6 teenth Sunday"
     },
     {
-      "name": "\"sunteenth of October 2013\"",
+      "name": "sunteenth of October 2013",
       "cmd": "bash meetup.sh 2013 10 teenth Sunday"
     },
     {
-      "name": "\"first Monday of March 2013\"",
+      "name": "first Monday of March 2013",
       "cmd": "bash meetup.sh 2013 3 first Monday"
     },
     {
-      "name": "\"first Monday of April 2013\"",
+      "name": "first Monday of April 2013",
       "cmd": "bash meetup.sh 2013 4 first Monday"
     },
     {
-      "name": "\"first Tuesday of May 2013\"",
+      "name": "first Tuesday of May 2013",
       "cmd": "bash meetup.sh 2013 5 first Tuesday"
     },
     {
-      "name": "\"first Tuesday of June 2013\"",
+      "name": "first Tuesday of June 2013",
       "cmd": "bash meetup.sh 2013 6 first Tuesday"
     },
     {
-      "name": "\"first Wednesday of July 2013\"",
+      "name": "first Wednesday of July 2013",
       "cmd": "bash meetup.sh 2013 7 first Wednesday"
     },
     {
-      "name": "\"first Wednesday of August 2013\"",
+      "name": "first Wednesday of August 2013",
       "cmd": "bash meetup.sh 2013 8 first Wednesday"
     },
     {
-      "name": "\"first Thursday of September 2013\"",
+      "name": "first Thursday of September 2013",
       "cmd": "bash meetup.sh 2013 9 first Thursday"
     },
     {
-      "name": "\"first Thursday of October 2013\"",
+      "name": "first Thursday of October 2013",
       "cmd": "bash meetup.sh 2013 10 first Thursday"
     },
     {
-      "name": "\"first Friday of November 2013\"",
+      "name": "first Friday of November 2013",
       "cmd": "bash meetup.sh 2013 11 first Friday"
     },
     {
-      "name": "\"first Friday of December 2013\"",
+      "name": "first Friday of December 2013",
       "cmd": "bash meetup.sh 2013 12 first Friday"
     },
     {
-      "name": "\"first Saturday of January 2013\"",
+      "name": "first Saturday of January 2013",
       "cmd": "bash meetup.sh 2013 1 first Saturday"
     },
     {
-      "name": "\"first Saturday of February 2013\"",
+      "name": "first Saturday of February 2013",
       "cmd": "bash meetup.sh 2013 2 first Saturday"
     },
     {
-      "name": "\"first Sunday of March 2013\"",
+      "name": "first Sunday of March 2013",
       "cmd": "bash meetup.sh 2013 3 first Sunday"
     },
     {
-      "name": "\"first Sunday of April 2013\"",
+      "name": "first Sunday of April 2013",
       "cmd": "bash meetup.sh 2013 4 first Sunday"
     },
     {
-      "name": "\"second Monday of March 2013\"",
+      "name": "second Monday of March 2013",
       "cmd": "bash meetup.sh 2013 3 second Monday"
     },
     {
-      "name": "\"second Monday of April 2013\"",
+      "name": "second Monday of April 2013",
       "cmd": "bash meetup.sh 2013 4 second Monday"
     },
     {
-      "name": "\"second Tuesday of May 2013\"",
+      "name": "second Tuesday of May 2013",
       "cmd": "bash meetup.sh 2013 5 second Tuesday"
     },
     {
-      "name": "\"second Tuesday of June 2013\"",
+      "name": "second Tuesday of June 2013",
       "cmd": "bash meetup.sh 2013 6 second Tuesday"
     },
     {
-      "name": "\"second Wednesday of July 2013\"",
+      "name": "second Wednesday of July 2013",
       "cmd": "bash meetup.sh 2013 7 second Wednesday"
     },
     {
-      "name": "\"second Wednesday of August 2013\"",
+      "name": "second Wednesday of August 2013",
       "cmd": "bash meetup.sh 2013 8 second Wednesday"
     },
     {
-      "name": "\"second Thursday of September 2013\"",
+      "name": "second Thursday of September 2013",
       "cmd": "bash meetup.sh 2013 9 second Thursday"
     },
     {
-      "name": "\"second Thursday of October 2013\"",
+      "name": "second Thursday of October 2013",
       "cmd": "bash meetup.sh 2013 10 second Thursday"
     },
     {
-      "name": "\"second Friday of November 2013\"",
+      "name": "second Friday of November 2013",
       "cmd": "bash meetup.sh 2013 11 second Friday"
     },
     {
-      "name": "\"second Friday of December 2013\"",
+      "name": "second Friday of December 2013",
       "cmd": "bash meetup.sh 2013 12 second Friday"
     },
     {
-      "name": "\"second Saturday of January 2013\"",
+      "name": "second Saturday of January 2013",
       "cmd": "bash meetup.sh 2013 1 second Saturday"
     },
     {
-      "name": "\"second Saturday of February 2013\"",
+      "name": "second Saturday of February 2013",
       "cmd": "bash meetup.sh 2013 2 second Saturday"
     },
     {
-      "name": "\"second Sunday of March 2013\"",
+      "name": "second Sunday of March 2013",
       "cmd": "bash meetup.sh 2013 3 second Sunday"
     },
     {
-      "name": "\"second Sunday of April 2013\"",
+      "name": "second Sunday of April 2013",
       "cmd": "bash meetup.sh 2013 4 second Sunday"
     },
     {
-      "name": "\"third Monday of March 2013\"",
+      "name": "third Monday of March 2013",
       "cmd": "bash meetup.sh 2013 3 third Monday"
     },
     {
-      "name": "\"third Monday of April 2013\"",
+      "name": "third Monday of April 2013",
       "cmd": "bash meetup.sh 2013 4 third Monday"
     },
     {
-      "name": "\"third Tuesday of May 2013\"",
+      "name": "third Tuesday of May 2013",
       "cmd": "bash meetup.sh 2013 5 third Tuesday"
     },
     {
-      "name": "\"third Tuesday of June 2013\"",
+      "name": "third Tuesday of June 2013",
       "cmd": "bash meetup.sh 2013 6 third Tuesday"
     },
     {
-      "name": "\"third Wednesday of July 2013\"",
+      "name": "third Wednesday of July 2013",
       "cmd": "bash meetup.sh 2013 7 third Wednesday"
     },
     {
-      "name": "\"third Wednesday of August 2013\"",
+      "name": "third Wednesday of August 2013",
       "cmd": "bash meetup.sh 2013 8 third Wednesday"
     },
     {
-      "name": "\"third Thursday of September 2013\"",
+      "name": "third Thursday of September 2013",
       "cmd": "bash meetup.sh 2013 9 third Thursday"
     },
     {
-      "name": "\"third Thursday of October 2013\"",
+      "name": "third Thursday of October 2013",
       "cmd": "bash meetup.sh 2013 10 third Thursday"
     },
     {
-      "name": "\"third Friday of November 2013\"",
+      "name": "third Friday of November 2013",
       "cmd": "bash meetup.sh 2013 11 third Friday"
     },
     {
-      "name": "\"third Friday of December 2013\"",
+      "name": "third Friday of December 2013",
       "cmd": "bash meetup.sh 2013 12 third Friday"
     },
     {
-      "name": "\"third Saturday of January 2013\"",
+      "name": "third Saturday of January 2013",
       "cmd": "bash meetup.sh 2013 1 third Saturday"
     },
     {
-      "name": "\"third Saturday of February 2013\"",
+      "name": "third Saturday of February 2013",
       "cmd": "bash meetup.sh 2013 2 third Saturday"
     },
     {
-      "name": "\"third Sunday of March 2013\"",
+      "name": "third Sunday of March 2013",
       "cmd": "bash meetup.sh 2013 3 third Sunday"
     },
     {
-      "name": "\"third Sunday of April 2013\"",
+      "name": "third Sunday of April 2013",
       "cmd": "bash meetup.sh 2013 4 third Sunday"
     },
     {
-      "name": "\"fourth Monday of March 2013\"",
+      "name": "fourth Monday of March 2013",
       "cmd": "bash meetup.sh 2013 3 fourth Monday"
     },
     {
-      "name": "\"fourth Monday of April 2013\"",
+      "name": "fourth Monday of April 2013",
       "cmd": "bash meetup.sh 2013 4 fourth Monday"
     },
     {
-      "name": "\"fourth Tuesday of May 2013\"",
+      "name": "fourth Tuesday of May 2013",
       "cmd": "bash meetup.sh 2013 5 fourth Tuesday"
     },
     {
-      "name": "\"fourth Tuesday of June 2013\"",
+      "name": "fourth Tuesday of June 2013",
       "cmd": "bash meetup.sh 2013 6 fourth Tuesday"
     },
     {
-      "name": "\"fourth Wednesday of July 2013\"",
+      "name": "fourth Wednesday of July 2013",
       "cmd": "bash meetup.sh 2013 7 fourth Wednesday"
     },
     {
-      "name": "\"fourth Wednesday of August 2013\"",
+      "name": "fourth Wednesday of August 2013",
       "cmd": "bash meetup.sh 2013 8 fourth Wednesday"
     },
     {
-      "name": "\"fourth Thursday of September 2013\"",
+      "name": "fourth Thursday of September 2013",
       "cmd": "bash meetup.sh 2013 9 fourth Thursday"
     },
     {
-      "name": "\"fourth Thursday of October 2013\"",
+      "name": "fourth Thursday of October 2013",
       "cmd": "bash meetup.sh 2013 10 fourth Thursday"
     },
     {
-      "name": "\"fourth Friday of November 2013\"",
+      "name": "fourth Friday of November 2013",
       "cmd": "bash meetup.sh 2013 11 fourth Friday"
     },
     {
-      "name": "\"fourth Friday of December 2013\"",
+      "name": "fourth Friday of December 2013",
       "cmd": "bash meetup.sh 2013 12 fourth Friday"
     },
     {
-      "name": "\"fourth Saturday of January 2013\"",
+      "name": "fourth Saturday of January 2013",
       "cmd": "bash meetup.sh 2013 1 fourth Saturday"
     },
     {
-      "name": "\"fourth Saturday of February 2013\"",
+      "name": "fourth Saturday of February 2013",
       "cmd": "bash meetup.sh 2013 2 fourth Saturday"
     },
     {
-      "name": "\"fourth Sunday of March 2013\"",
+      "name": "fourth Sunday of March 2013",
       "cmd": "bash meetup.sh 2013 3 fourth Sunday"
     },
     {
-      "name": "\"fourth Sunday of April 2013\"",
+      "name": "fourth Sunday of April 2013",
       "cmd": "bash meetup.sh 2013 4 fourth Sunday"
     },
     {
-      "name": "\"last Monday of March 2013\"",
+      "name": "last Monday of March 2013",
       "cmd": "bash meetup.sh 2013 3 last Monday"
     },
     {
-      "name": "\"last Monday of April 2013\"",
+      "name": "last Monday of April 2013",
       "cmd": "bash meetup.sh 2013 4 last Monday"
     },
     {
-      "name": "\"last Tuesday of May 2013\"",
+      "name": "last Tuesday of May 2013",
       "cmd": "bash meetup.sh 2013 5 last Tuesday"
     },
     {
-      "name": "\"last Tuesday of June 2013\"",
+      "name": "last Tuesday of June 2013",
       "cmd": "bash meetup.sh 2013 6 last Tuesday"
     },
     {
-      "name": "\"last Wednesday of July 2013\"",
+      "name": "last Wednesday of July 2013",
       "cmd": "bash meetup.sh 2013 7 last Wednesday"
     },
     {
-      "name": "\"last Wednesday of August 2013\"",
+      "name": "last Wednesday of August 2013",
       "cmd": "bash meetup.sh 2013 8 last Wednesday"
     },
     {
-      "name": "\"last Thursday of September 2013\"",
+      "name": "last Thursday of September 2013",
       "cmd": "bash meetup.sh 2013 9 last Thursday"
     },
     {
-      "name": "\"last Thursday of October 2013\"",
+      "name": "last Thursday of October 2013",
       "cmd": "bash meetup.sh 2013 10 last Thursday"
     },
     {
-      "name": "\"last Friday of November 2013\"",
+      "name": "last Friday of November 2013",
       "cmd": "bash meetup.sh 2013 11 last Friday"
     },
     {
-      "name": "\"last Friday of December 2013\"",
+      "name": "last Friday of December 2013",
       "cmd": "bash meetup.sh 2013 12 last Friday"
     },
     {
-      "name": "\"last Saturday of January 2013\"",
+      "name": "last Saturday of January 2013",
       "cmd": "bash meetup.sh 2013 1 last Saturday"
     },
     {
-      "name": "\"last Saturday of February 2013\"",
+      "name": "last Saturday of February 2013",
       "cmd": "bash meetup.sh 2013 2 last Saturday"
     },
     {
-      "name": "\"last Sunday of March 2013\"",
+      "name": "last Sunday of March 2013",
       "cmd": "bash meetup.sh 2013 3 last Sunday"
     },
     {
-      "name": "\"last Sunday of April 2013\"",
+      "name": "last Sunday of April 2013",
       "cmd": "bash meetup.sh 2013 4 last Sunday"
     },
     {
-      "name": "\"last Wednesday of February 2012\"",
+      "name": "last Wednesday of February 2012",
       "cmd": "bash meetup.sh 2012 2 last Wednesday"
     },
     {
-      "name": "\"last Wednesday of December 2014\"",
+      "name": "last Wednesday of December 2014",
       "cmd": "bash meetup.sh 2014 12 last Wednesday"
     },
     {
-      "name": "\"last Sunday of February 2015\"",
+      "name": "last Sunday of February 2015",
       "cmd": "bash meetup.sh 2015 2 last Sunday"
     },
     {
-      "name": "\"first Friday of December 2012\"",
+      "name": "first Friday of December 2012",
       "cmd": "bash meetup.sh 2012 12 first Friday"
     }
   ]

--- a/exercises/nth-prime/.meta/config.json
+++ b/exercises/nth-prime/.meta/config.json
@@ -4,31 +4,31 @@
   ],
   "tests": [
     {
-      "name": "\"first prime\"",
+      "name": "first prime",
       "cmd": "bash nth_prime.sh 1"
     },
     {
-      "name": "\"second prime\"",
+      "name": "second prime",
       "cmd": "bash nth_prime.sh 2"
     },
     {
-      "name": "\"sixth prime\"",
+      "name": "sixth prime",
       "cmd": "bash nth_prime.sh 6"
     },
     {
-      "name": "\"hundredth prime\"",
+      "name": "hundredth prime",
       "cmd": "bash nth_prime.sh 100"
     },
     {
-      "name": "\"big prime\"",
+      "name": "big prime",
       "cmd": "bash nth_prime.sh 10001"
     },
     {
-      "name": "\"there is no zeroth prime\"",
+      "name": "there is no zeroth prime",
       "cmd": "bash nth_prime.sh 0"
     },
     {
-      "name": "\"there is no negativeth prime\"",
+      "name": "there is no negativeth prime",
       "cmd": "bash nth_prime.sh -2"
     }
   ]

--- a/exercises/nth-prime/.meta/config.json
+++ b/exercises/nth-prime/.meta/config.json
@@ -1,0 +1,35 @@
+{
+  "solution_files": [
+    "nth_prime.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"first prime\"",
+      "cmd": "bash nth_prime.sh 1"
+    },
+    {
+      "name": "\"second prime\"",
+      "cmd": "bash nth_prime.sh 2"
+    },
+    {
+      "name": "\"sixth prime\"",
+      "cmd": "bash nth_prime.sh 6"
+    },
+    {
+      "name": "\"hundredth prime\"",
+      "cmd": "bash nth_prime.sh 100"
+    },
+    {
+      "name": "\"big prime\"",
+      "cmd": "bash nth_prime.sh 10001"
+    },
+    {
+      "name": "\"there is no zeroth prime\"",
+      "cmd": "bash nth_prime.sh 0"
+    },
+    {
+      "name": "\"there is no negativeth prime\"",
+      "cmd": "bash nth_prime.sh -2"
+    }
+  ]
+}

--- a/exercises/nucleotide-count/.meta/config.json
+++ b/exercises/nucleotide-count/.meta/config.json
@@ -4,23 +4,23 @@
   ],
   "tests": [
     {
-      "name": "\"empty strand\"",
+      "name": "empty strand",
       "cmd": "bash nucleotide_count.sh \"\""
     },
     {
-      "name": "\"can count one nucleotide in single-character input\"",
+      "name": "can count one nucleotide in single-character input",
       "cmd": "bash nucleotide_count.sh \"G\""
     },
     {
-      "name": "\"strand with repeated nucleotide\"",
+      "name": "strand with repeated nucleotide",
       "cmd": "bash nucleotide_count.sh \"GGGGGGG\""
     },
     {
-      "name": "\"strand with multiple nucleotides\"",
+      "name": "strand with multiple nucleotides",
       "cmd": "bash nucleotide_count.sh \"AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC\""
     },
     {
-      "name": "\"strand with invalid nucleotides\"",
+      "name": "strand with invalid nucleotides",
       "cmd": "bash nucleotide_count.sh \"AGXXACT\""
     }
   ]

--- a/exercises/nucleotide-count/.meta/config.json
+++ b/exercises/nucleotide-count/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "nucleotide_count.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"empty strand\"",
+      "cmd": "bash nucleotide_count.sh \"\""
+    },
+    {
+      "name": "\"can count one nucleotide in single-character input\"",
+      "cmd": "bash nucleotide_count.sh \"G\""
+    },
+    {
+      "name": "\"strand with repeated nucleotide\"",
+      "cmd": "bash nucleotide_count.sh \"GGGGGGG\""
+    },
+    {
+      "name": "\"strand with multiple nucleotides\"",
+      "cmd": "bash nucleotide_count.sh \"AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC\""
+    },
+    {
+      "name": "\"strand with invalid nucleotides\"",
+      "cmd": "bash nucleotide_count.sh \"AGXXACT\""
+    }
+  ]
+}

--- a/exercises/ocr-numbers/.meta/config.json
+++ b/exercises/ocr-numbers/.meta/config.json
@@ -1,0 +1,79 @@
+{
+  "solution_files": [
+    "ocr_numbers.sh"
+  ],
+  "tests": [
+    {
+      "name": "No input",
+      "cmd": "bash ocr_numbers.sh"
+    },
+    {
+      "name": "Recognizes 0",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 1",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Unreadable but correctly sized inputs return ?",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Input with a number of lines that is not a multiple of four raises an error",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Input with a number of columns that is not a multiple of three raises an error",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 110101100",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Garbled numbers in a string are replaced with ?",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 2",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 3",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 4",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 5",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 6",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 7",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 8",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes 9",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Recognizes string of decimal numbers",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    },
+    {
+      "name": "Numbers separated by empty lines are recognized. Lines are joined by commas.",
+      "cmd": "bash ocr_numbers.sh << INPUT"
+    }
+  ]
+}

--- a/exercises/ocr-numbers/.meta/config.json
+++ b/exercises/ocr-numbers/.meta/config.json
@@ -9,71 +9,71 @@
     },
     {
       "name": "Recognizes 0",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 1",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Unreadable but correctly sized inputs return ?",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Input with a number of lines that is not a multiple of four raises an error",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Input with a number of columns that is not a multiple of three raises an error",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 110101100",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Garbled numbers in a string are replaced with ?",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 2",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 3",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 4",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 5",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 6",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 7",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 8",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes 9",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Recognizes string of decimal numbers",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     },
     {
       "name": "Numbers separated by empty lines are recognized. Lines are joined by commas.",
-      "cmd": "bash ocr_numbers.sh << INPUT"
+      "cmd": "bash ocr_numbers.sh"
     }
   ]
 }

--- a/exercises/palindrome-products/.meta/config.json
+++ b/exercises/palindrome-products/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "palindrome_products.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"finds the smallest palindrome from single digit factors\"",
+      "cmd": "bash palindrome_products.sh smallest 1 9"
+    },
+    {
+      "name": "\"finds the largest palindrome from single digit factors\"",
+      "cmd": "bash palindrome_products.sh largest 1 9"
+    },
+    {
+      "name": "\"find the smallest palindrome from double digit factors\"",
+      "cmd": "bash palindrome_products.sh smallest 10 99"
+    },
+    {
+      "name": "\"find the largest palindrome from double digit factors\"",
+      "cmd": "bash palindrome_products.sh largest 10 99"
+    },
+    {
+      "name": "\"find smallest palindrome from triple digit factors\"",
+      "cmd": "bash palindrome_products.sh smallest 100 999"
+    },
+    {
+      "name": "\"find the largest palindrome from triple digit factors\"",
+      "cmd": "bash palindrome_products.sh largest 100 999"
+    },
+    {
+      "name": "\"find smallest palindrome from four digit factors\"",
+      "cmd": "bash palindrome_products.sh smallest 1000 9999"
+    },
+    {
+      "name": "\"find the largest palindrome from four digit factors\"",
+      "cmd": "bash palindrome_products.sh largest 1000 9999"
+    },
+    {
+      "name": "\"empty result for smallest if no palindrome in the range\"",
+      "cmd": "bash palindrome_products.sh smallest 1002 1003"
+    },
+    {
+      "name": "\"empty result for largest if no palindrome in the range\"",
+      "cmd": "bash palindrome_products.sh largest 15 15"
+    },
+    {
+      "name": "\"error result for smallest if min is more than max\"",
+      "cmd": "bash palindrome_products.sh smallest 10000 1"
+    },
+    {
+      "name": "\"error result for largest if min is more than max\"",
+      "cmd": "bash palindrome_products.sh largest 2 1"
+    },
+    {
+      "name": "\"error result for first param\"",
+      "cmd": "bash palindrome_products.sh foo 2 3"
+    }
+  ]
+}

--- a/exercises/palindrome-products/.meta/config.json
+++ b/exercises/palindrome-products/.meta/config.json
@@ -4,55 +4,55 @@
   ],
   "tests": [
     {
-      "name": "\"finds the smallest palindrome from single digit factors\"",
+      "name": "finds the smallest palindrome from single digit factors",
       "cmd": "bash palindrome_products.sh smallest 1 9"
     },
     {
-      "name": "\"finds the largest palindrome from single digit factors\"",
+      "name": "finds the largest palindrome from single digit factors",
       "cmd": "bash palindrome_products.sh largest 1 9"
     },
     {
-      "name": "\"find the smallest palindrome from double digit factors\"",
+      "name": "find the smallest palindrome from double digit factors",
       "cmd": "bash palindrome_products.sh smallest 10 99"
     },
     {
-      "name": "\"find the largest palindrome from double digit factors\"",
+      "name": "find the largest palindrome from double digit factors",
       "cmd": "bash palindrome_products.sh largest 10 99"
     },
     {
-      "name": "\"find smallest palindrome from triple digit factors\"",
+      "name": "find smallest palindrome from triple digit factors",
       "cmd": "bash palindrome_products.sh smallest 100 999"
     },
     {
-      "name": "\"find the largest palindrome from triple digit factors\"",
+      "name": "find the largest palindrome from triple digit factors",
       "cmd": "bash palindrome_products.sh largest 100 999"
     },
     {
-      "name": "\"find smallest palindrome from four digit factors\"",
+      "name": "find smallest palindrome from four digit factors",
       "cmd": "bash palindrome_products.sh smallest 1000 9999"
     },
     {
-      "name": "\"find the largest palindrome from four digit factors\"",
+      "name": "find the largest palindrome from four digit factors",
       "cmd": "bash palindrome_products.sh largest 1000 9999"
     },
     {
-      "name": "\"empty result for smallest if no palindrome in the range\"",
+      "name": "empty result for smallest if no palindrome in the range",
       "cmd": "bash palindrome_products.sh smallest 1002 1003"
     },
     {
-      "name": "\"empty result for largest if no palindrome in the range\"",
+      "name": "empty result for largest if no palindrome in the range",
       "cmd": "bash palindrome_products.sh largest 15 15"
     },
     {
-      "name": "\"error result for smallest if min is more than max\"",
+      "name": "error result for smallest if min is more than max",
       "cmd": "bash palindrome_products.sh smallest 10000 1"
     },
     {
-      "name": "\"error result for largest if min is more than max\"",
+      "name": "error result for largest if min is more than max",
       "cmd": "bash palindrome_products.sh largest 2 1"
     },
     {
-      "name": "\"error result for first param\"",
+      "name": "error result for first param",
       "cmd": "bash palindrome_products.sh foo 2 3"
     }
   ]

--- a/exercises/pangram/.meta/config.json
+++ b/exercises/pangram/.meta/config.json
@@ -4,43 +4,43 @@
   ],
   "tests": [
     {
-      "name": "\"empty sentence\"",
+      "name": "empty sentence",
       "cmd": "bash pangram.sh \"\""
     },
     {
-      "name": "\"perfect lower case\"",
+      "name": "perfect lower case",
       "cmd": "bash pangram.sh \"abcdefghijklmnopqrstuvwxyz\""
     },
     {
-      "name": "\"only lower case\"",
+      "name": "only lower case",
       "cmd": "bash pangram.sh \"the quick brown fox jumps over the lazy dog\""
     },
     {
-      "name": "\"missing the letter 'x'\"",
+      "name": "missing the letter 'x'",
       "cmd": "bash pangram.sh \"a quick movement of the enemy will jeopardize five gunboats\""
     },
     {
-      "name": "\"missing the letter 'h'\"",
+      "name": "missing the letter 'h'",
       "cmd": "bash pangram.sh \"five boxing wizards jump quickly at it\""
     },
     {
-      "name": "\"with underscores\"",
+      "name": "with underscores",
       "cmd": "bash pangram.sh \"the_quick_brown_fox_jumps_over_the_lazy_dog\""
     },
     {
-      "name": "\"with numbers\"",
+      "name": "with numbers",
       "cmd": "bash pangram.sh \"the 1 quick brown fox jumps over the 2 lazy dogs\""
     },
     {
-      "name": "\"missing letters replaced by numbers\"",
+      "name": "missing letters replaced by numbers",
       "cmd": "bash pangram.sh \"7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog\""
     },
     {
-      "name": "\"mixed case and punctuation\"",
+      "name": "mixed case and punctuation",
       "cmd": "bash pangram.sh \"\\\"Five quacking Zephyrs jolt my wax bed.\\\"\""
     },
     {
-      "name": "\"case insensitive\"",
+      "name": "case insensitive",
       "cmd": "bash pangram.sh \"the quick brown fox jumps over with lazy FX\""
     }
   ]

--- a/exercises/pangram/.meta/config.json
+++ b/exercises/pangram/.meta/config.json
@@ -1,0 +1,47 @@
+{
+  "solution_files": [
+    "pangram.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"empty sentence\"",
+      "cmd": "bash pangram.sh \"\""
+    },
+    {
+      "name": "\"perfect lower case\"",
+      "cmd": "bash pangram.sh \"abcdefghijklmnopqrstuvwxyz\""
+    },
+    {
+      "name": "\"only lower case\"",
+      "cmd": "bash pangram.sh \"the quick brown fox jumps over the lazy dog\""
+    },
+    {
+      "name": "\"missing the letter 'x'\"",
+      "cmd": "bash pangram.sh \"a quick movement of the enemy will jeopardize five gunboats\""
+    },
+    {
+      "name": "\"missing the letter 'h'\"",
+      "cmd": "bash pangram.sh \"five boxing wizards jump quickly at it\""
+    },
+    {
+      "name": "\"with underscores\"",
+      "cmd": "bash pangram.sh \"the_quick_brown_fox_jumps_over_the_lazy_dog\""
+    },
+    {
+      "name": "\"with numbers\"",
+      "cmd": "bash pangram.sh \"the 1 quick brown fox jumps over the 2 lazy dogs\""
+    },
+    {
+      "name": "\"missing letters replaced by numbers\"",
+      "cmd": "bash pangram.sh \"7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog\""
+    },
+    {
+      "name": "\"mixed case and punctuation\"",
+      "cmd": "bash pangram.sh \"\\\"Five quacking Zephyrs jolt my wax bed.\\\"\""
+    },
+    {
+      "name": "\"case insensitive\"",
+      "cmd": "bash pangram.sh \"the quick brown fox jumps over with lazy FX\""
+    }
+  ]
+}

--- a/exercises/pascals-triangle/.meta/config.json
+++ b/exercises/pascals-triangle/.meta/config.json
@@ -1,0 +1,43 @@
+{
+  "solution_files": [
+    "pascals_triangle.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"zero rows\"",
+      "cmd": "bash pascals_triangle.sh 0"
+    },
+    {
+      "name": "\"single row\"",
+      "cmd": "bash pascals_triangle.sh 1"
+    },
+    {
+      "name": "\"two rows\"",
+      "cmd": "bash pascals_triangle.sh 2"
+    },
+    {
+      "name": "\"three rows\"",
+      "cmd": "bash pascals_triangle.sh 3"
+    },
+    {
+      "name": "\"four rows\"",
+      "cmd": "bash pascals_triangle.sh 4"
+    },
+    {
+      "name": "\"five rows\"",
+      "cmd": "bash pascals_triangle.sh 5"
+    },
+    {
+      "name": "\"six rows\"",
+      "cmd": "bash pascals_triangle.sh 6"
+    },
+    {
+      "name": "\"ten rows\"",
+      "cmd": "bash pascals_triangle.sh 10"
+    },
+    {
+      "name": "\"21 rows\"",
+      "cmd": "bash pascals_triangle.sh 21"
+    }
+  ]
+}

--- a/exercises/pascals-triangle/.meta/config.json
+++ b/exercises/pascals-triangle/.meta/config.json
@@ -4,39 +4,39 @@
   ],
   "tests": [
     {
-      "name": "\"zero rows\"",
+      "name": "zero rows",
       "cmd": "bash pascals_triangle.sh 0"
     },
     {
-      "name": "\"single row\"",
+      "name": "single row",
       "cmd": "bash pascals_triangle.sh 1"
     },
     {
-      "name": "\"two rows\"",
+      "name": "two rows",
       "cmd": "bash pascals_triangle.sh 2"
     },
     {
-      "name": "\"three rows\"",
+      "name": "three rows",
       "cmd": "bash pascals_triangle.sh 3"
     },
     {
-      "name": "\"four rows\"",
+      "name": "four rows",
       "cmd": "bash pascals_triangle.sh 4"
     },
     {
-      "name": "\"five rows\"",
+      "name": "five rows",
       "cmd": "bash pascals_triangle.sh 5"
     },
     {
-      "name": "\"six rows\"",
+      "name": "six rows",
       "cmd": "bash pascals_triangle.sh 6"
     },
     {
-      "name": "\"ten rows\"",
+      "name": "ten rows",
       "cmd": "bash pascals_triangle.sh 10"
     },
     {
-      "name": "\"21 rows\"",
+      "name": "21 rows",
       "cmd": "bash pascals_triangle.sh 21"
     }
   ]

--- a/exercises/perfect-numbers/.meta/config.json
+++ b/exercises/perfect-numbers/.meta/config.json
@@ -4,55 +4,55 @@
   ],
   "tests": [
     {
-      "name": "\"Smallest perfect number is classified correctly\"",
+      "name": "Smallest perfect number is classified correctly",
       "cmd": "bash perfect_numbers.sh 6"
     },
     {
-      "name": "\"Medium perfect number is classified correctly\"",
+      "name": "Medium perfect number is classified correctly",
       "cmd": "bash perfect_numbers.sh 28"
     },
     {
-      "name": "\"Large perfect number is classified correctly\"",
+      "name": "Large perfect number is classified correctly",
       "cmd": "bash perfect_numbers.sh 33550336"
     },
     {
-      "name": "\"Smallest abundant number is classified correctly\"",
+      "name": "Smallest abundant number is classified correctly",
       "cmd": "bash perfect_numbers.sh 12"
     },
     {
-      "name": "\"Medium abundant number is classified correctly\"",
+      "name": "Medium abundant number is classified correctly",
       "cmd": "bash perfect_numbers.sh 30"
     },
     {
-      "name": "\"Large abundant number is classified correctly\"",
+      "name": "Large abundant number is classified correctly",
       "cmd": "bash perfect_numbers.sh 33550335"
     },
     {
-      "name": "\"Smallest prime deficient number is classified correctly\"",
+      "name": "Smallest prime deficient number is classified correctly",
       "cmd": "bash perfect_numbers.sh 2"
     },
     {
-      "name": "\"Smallest non-prime deficient number is classified correctly\"",
+      "name": "Smallest non-prime deficient number is classified correctly",
       "cmd": "bash perfect_numbers.sh 4"
     },
     {
-      "name": "\"Medium deficient number is classified correctly\"",
+      "name": "Medium deficient number is classified correctly",
       "cmd": "bash perfect_numbers.sh 32"
     },
     {
-      "name": "\"Large deficient number is classified correctly\"",
+      "name": "Large deficient number is classified correctly",
       "cmd": "bash perfect_numbers.sh 33550337"
     },
     {
-      "name": "\"Edge case (no factors other than itself) is classified correctly\"",
+      "name": "Edge case (no factors other than itself) is classified correctly",
       "cmd": "bash perfect_numbers.sh 1"
     },
     {
-      "name": "\"Zero is rejected (not a natural number)\"",
+      "name": "Zero is rejected (not a natural number)",
       "cmd": "bash perfect_numbers.sh 0"
     },
     {
-      "name": "\"Negative integer is rejected (not a natural number)\"",
+      "name": "Negative integer is rejected (not a natural number)",
       "cmd": "bash perfect_numbers.sh -1"
     }
   ]

--- a/exercises/perfect-numbers/.meta/config.json
+++ b/exercises/perfect-numbers/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "perfect_numbers.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Smallest perfect number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 6"
+    },
+    {
+      "name": "\"Medium perfect number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 28"
+    },
+    {
+      "name": "\"Large perfect number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 33550336"
+    },
+    {
+      "name": "\"Smallest abundant number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 12"
+    },
+    {
+      "name": "\"Medium abundant number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 30"
+    },
+    {
+      "name": "\"Large abundant number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 33550335"
+    },
+    {
+      "name": "\"Smallest prime deficient number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 2"
+    },
+    {
+      "name": "\"Smallest non-prime deficient number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 4"
+    },
+    {
+      "name": "\"Medium deficient number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 32"
+    },
+    {
+      "name": "\"Large deficient number is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 33550337"
+    },
+    {
+      "name": "\"Edge case (no factors other than itself) is classified correctly\"",
+      "cmd": "bash perfect_numbers.sh 1"
+    },
+    {
+      "name": "\"Zero is rejected (not a natural number)\"",
+      "cmd": "bash perfect_numbers.sh 0"
+    },
+    {
+      "name": "\"Negative integer is rejected (not a natural number)\"",
+      "cmd": "bash perfect_numbers.sh -1"
+    }
+  ]
+}

--- a/exercises/phone-number/.meta/config.json
+++ b/exercises/phone-number/.meta/config.json
@@ -1,0 +1,79 @@
+{
+  "solution_files": [
+    "phone_number.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"cleans the number\"",
+      "cmd": "bash phone_number.sh \"(223) 456-7890\""
+    },
+    {
+      "name": "\"cleans numbers with dots\"",
+      "cmd": "bash phone_number.sh \"223.456.7890\""
+    },
+    {
+      "name": "\"cleans numbers with multiple spaces\"",
+      "cmd": "bash phone_number.sh \"223 456 7890 \""
+    },
+    {
+      "name": "\"invalid when 9 digits\"",
+      "cmd": "bash phone_number.sh \"123456789\""
+    },
+    {
+      "name": "\"invalid when 11 digits does not start with a 1\"",
+      "cmd": "bash phone_number.sh \"22234567890\""
+    },
+    {
+      "name": "\"valid when 11 digits and starting with 1\"",
+      "cmd": "bash phone_number.sh \"12234567890\""
+    },
+    {
+      "name": "\"valid when 11 digits and starting with 1 even with punctuation\"",
+      "cmd": "bash phone_number.sh \"+1 (223) 456-7890\""
+    },
+    {
+      "name": "\"invalid when more than 11 digits\"",
+      "cmd": "bash phone_number.sh \"321234567890\""
+    },
+    {
+      "name": "\"invalid with letters\"",
+      "cmd": "bash phone_number.sh \"123-abc-7890\""
+    },
+    {
+      "name": "\"invalid with punctuations\"",
+      "cmd": "bash phone_number.sh \"123-@:!-7890\""
+    },
+    {
+      "name": "\"invalid if area code starts with 0\"",
+      "cmd": "bash phone_number.sh \"(023) 456-7890\""
+    },
+    {
+      "name": "\"invalid if area code starts with 1\"",
+      "cmd": "bash phone_number.sh \"(123) 456-7890\""
+    },
+    {
+      "name": "\"invalid if exchange code starts with 0\"",
+      "cmd": "bash phone_number.sh \"(223) 056-7890\""
+    },
+    {
+      "name": "\"invalid if exchange code starts with 1\"",
+      "cmd": "bash phone_number.sh \"(223) 156-7890\""
+    },
+    {
+      "name": "\"invalid if area code starts with 0 on valid 11-digit number\"",
+      "cmd": "bash phone_number.sh \"1 (023) 456-7890\""
+    },
+    {
+      "name": "\"invalid if area code starts with 1 on valid 11-digit number\"",
+      "cmd": "bash phone_number.sh \"1 (123) 456-7890\""
+    },
+    {
+      "name": "\"invalid if exchange code starts with 0 on valid 11-digit number\"",
+      "cmd": "bash phone_number.sh \"1 (223) 056-7890\""
+    },
+    {
+      "name": "\"invalid if exchange code starts with 1 on valid 11-digit number\"",
+      "cmd": "bash phone_number.sh \"1 (223) 156-7890\""
+    }
+  ]
+}

--- a/exercises/phone-number/.meta/config.json
+++ b/exercises/phone-number/.meta/config.json
@@ -4,75 +4,75 @@
   ],
   "tests": [
     {
-      "name": "\"cleans the number\"",
+      "name": "cleans the number",
       "cmd": "bash phone_number.sh \"(223) 456-7890\""
     },
     {
-      "name": "\"cleans numbers with dots\"",
+      "name": "cleans numbers with dots",
       "cmd": "bash phone_number.sh \"223.456.7890\""
     },
     {
-      "name": "\"cleans numbers with multiple spaces\"",
+      "name": "cleans numbers with multiple spaces",
       "cmd": "bash phone_number.sh \"223 456 7890 \""
     },
     {
-      "name": "\"invalid when 9 digits\"",
+      "name": "invalid when 9 digits",
       "cmd": "bash phone_number.sh \"123456789\""
     },
     {
-      "name": "\"invalid when 11 digits does not start with a 1\"",
+      "name": "invalid when 11 digits does not start with a 1",
       "cmd": "bash phone_number.sh \"22234567890\""
     },
     {
-      "name": "\"valid when 11 digits and starting with 1\"",
+      "name": "valid when 11 digits and starting with 1",
       "cmd": "bash phone_number.sh \"12234567890\""
     },
     {
-      "name": "\"valid when 11 digits and starting with 1 even with punctuation\"",
+      "name": "valid when 11 digits and starting with 1 even with punctuation",
       "cmd": "bash phone_number.sh \"+1 (223) 456-7890\""
     },
     {
-      "name": "\"invalid when more than 11 digits\"",
+      "name": "invalid when more than 11 digits",
       "cmd": "bash phone_number.sh \"321234567890\""
     },
     {
-      "name": "\"invalid with letters\"",
+      "name": "invalid with letters",
       "cmd": "bash phone_number.sh \"123-abc-7890\""
     },
     {
-      "name": "\"invalid with punctuations\"",
+      "name": "invalid with punctuations",
       "cmd": "bash phone_number.sh \"123-@:!-7890\""
     },
     {
-      "name": "\"invalid if area code starts with 0\"",
+      "name": "invalid if area code starts with 0",
       "cmd": "bash phone_number.sh \"(023) 456-7890\""
     },
     {
-      "name": "\"invalid if area code starts with 1\"",
+      "name": "invalid if area code starts with 1",
       "cmd": "bash phone_number.sh \"(123) 456-7890\""
     },
     {
-      "name": "\"invalid if exchange code starts with 0\"",
+      "name": "invalid if exchange code starts with 0",
       "cmd": "bash phone_number.sh \"(223) 056-7890\""
     },
     {
-      "name": "\"invalid if exchange code starts with 1\"",
+      "name": "invalid if exchange code starts with 1",
       "cmd": "bash phone_number.sh \"(223) 156-7890\""
     },
     {
-      "name": "\"invalid if area code starts with 0 on valid 11-digit number\"",
+      "name": "invalid if area code starts with 0 on valid 11-digit number",
       "cmd": "bash phone_number.sh \"1 (023) 456-7890\""
     },
     {
-      "name": "\"invalid if area code starts with 1 on valid 11-digit number\"",
+      "name": "invalid if area code starts with 1 on valid 11-digit number",
       "cmd": "bash phone_number.sh \"1 (123) 456-7890\""
     },
     {
-      "name": "\"invalid if exchange code starts with 0 on valid 11-digit number\"",
+      "name": "invalid if exchange code starts with 0 on valid 11-digit number",
       "cmd": "bash phone_number.sh \"1 (223) 056-7890\""
     },
     {
-      "name": "\"invalid if exchange code starts with 1 on valid 11-digit number\"",
+      "name": "invalid if exchange code starts with 1 on valid 11-digit number",
       "cmd": "bash phone_number.sh \"1 (223) 156-7890\""
     }
   ]

--- a/exercises/pig-latin/.meta/config.json
+++ b/exercises/pig-latin/.meta/config.json
@@ -88,7 +88,7 @@
       "cmd": "bash pig_latin.sh quick fast run"
     },
     {
-      "name": "\"shell globbing\"",
+      "name": "shell globbing",
       "cmd": "bash pig_latin.sh \"pig*\""
     }
   ]

--- a/exercises/pig-latin/.meta/config.json
+++ b/exercises/pig-latin/.meta/config.json
@@ -1,0 +1,95 @@
+{
+  "solution_files": [
+    "pig_latin.sh"
+  ],
+  "tests": [
+    {
+      "name": "word_beginning_with_a",
+      "cmd": "bash pig_latin.sh apple"
+    },
+    {
+      "name": "word_beginning_with_e",
+      "cmd": "bash pig_latin.sh ear"
+    },
+    {
+      "name": "word_beginning_with_i",
+      "cmd": "bash pig_latin.sh igloo"
+    },
+    {
+      "name": "word_beginning_with_o",
+      "cmd": "bash pig_latin.sh object"
+    },
+    {
+      "name": "word_beginning_with_u",
+      "cmd": "bash pig_latin.sh under"
+    },
+    {
+      "name": "word_beginning_with_equ",
+      "cmd": "bash pig_latin.sh equal"
+    },
+    {
+      "name": "word_beginning_with_p",
+      "cmd": "bash pig_latin.sh pig"
+    },
+    {
+      "name": "word_beginning_with_k",
+      "cmd": "bash pig_latin.sh koala"
+    },
+    {
+      "name": "word_beginning_with_x",
+      "cmd": "bash pig_latin.sh xenon"
+    },
+    {
+      "name": "word_beginning_with_q_no_u",
+      "cmd": "bash pig_latin.sh qat"
+    },
+    {
+      "name": "word_beginning_with_ch",
+      "cmd": "bash pig_latin.sh chair"
+    },
+    {
+      "name": "word_beginning_with_squ",
+      "cmd": "bash pig_latin.sh square"
+    },
+    {
+      "name": "word_beginning_with_th",
+      "cmd": "bash pig_latin.sh therapy"
+    },
+    {
+      "name": "word_beginning_with_thr",
+      "cmd": "bash pig_latin.sh thrush"
+    },
+    {
+      "name": "word_beginning_with_sch",
+      "cmd": "bash pig_latin.sh school"
+    },
+    {
+      "name": "word_beginning_with_yt",
+      "cmd": "bash pig_latin.sh yttria"
+    },
+    {
+      "name": "word_beginning_with_xr",
+      "cmd": "bash pig_latin.sh xray"
+    },
+    {
+      "name": "word_beginning_with_y",
+      "cmd": "bash pig_latin.sh yellow"
+    },
+    {
+      "name": "word_rhythm",
+      "cmd": "bash pig_latin.sh rhythm"
+    },
+    {
+      "name": "word_my",
+      "cmd": "bash pig_latin.sh my"
+    },
+    {
+      "name": "a_whole_phrase",
+      "cmd": "bash pig_latin.sh quick fast run"
+    },
+    {
+      "name": "\"shell globbing\"",
+      "cmd": "bash pig_latin.sh \"pig*\""
+    }
+  ]
+}

--- a/exercises/poker/.meta/config.json
+++ b/exercises/poker/.meta/config.json
@@ -1,0 +1,119 @@
+{
+  "solution_files": [
+    "poker.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"single hand always wins\"",
+      "cmd": "bash poker.sh \"4S 5S 7H 8D JC\""
+    },
+    {
+      "name": "\"highest card out of all hands wins\"",
+      "cmd": "bash poker.sh \"4D 5S 6S 8D 3C\" \"2S 4C 7S 9H 10H\" \"3S 4S 5D 6H JH\""
+    },
+    {
+      "name": "\"a tie has multiple winners\"",
+      "cmd": "bash poker.sh \"4D 5S 6S 8D 3C\" \"2S 4C 7S 9H 10H\" \"3S 4S 5D 6H JH\" \"3H 4H 5C 6C JD\""
+    },
+    {
+      "name": "\"multiple hands with the same high cards, tie compares next highest ranked, down to last card\"",
+      "cmd": "bash poker.sh \"3S 5H 6S 8D 7H\" \"2S 5D 6D 8C 7S\""
+    },
+    {
+      "name": "\"one pair beats high card\"",
+      "cmd": "bash poker.sh \"4S 5H 6C 8D KH\" \"2S 4H 6S 4D JH\""
+    },
+    {
+      "name": "\"highest pair wins\"",
+      "cmd": "bash poker.sh \"4S 2H 6S 2D JH\" \"2S 4H 6C 4D JD\""
+    },
+    {
+      "name": "\"two pairs beats one pair\"",
+      "cmd": "bash poker.sh \"2S 8H 6S 8D JH\" \"4S 5H 4C 8C 5C\""
+    },
+    {
+      "name": "\"both hands have two pairs, highest ranked pair wins\"",
+      "cmd": "bash poker.sh \"2S 8H 2D 8D 3H\" \"4S 5H 4C 8S 5D\""
+    },
+    {
+      "name": "\"both hands have two pairs, with the same highest ranked pair, tie goes to low pair\"",
+      "cmd": "bash poker.sh \"2S QS 2C QD JH\" \"JD QH JS 8D QC\""
+    },
+    {
+      "name": "\"both hands have two identically ranked pairs, tie goes to remaining card (kicker)\"",
+      "cmd": "bash poker.sh \"JD QH JS 8D QC\" \"JS QS JC 2D QD\""
+    },
+    {
+      "name": "\"three of a kind beats two pair\"",
+      "cmd": "bash poker.sh \"2S 8H 2H 8D JH\" \"4S 5H 4C 8S 4H\""
+    },
+    {
+      "name": "\"both hands have three of a kind, tie goes to highest ranked triplet\"",
+      "cmd": "bash poker.sh \"2S 2H 2C 8D JH\" \"4S AH AS 8C AD\""
+    },
+    {
+      "name": "\"with multiple decks, two players can have same three of a kind, ties go to highest remaining cards\"",
+      "cmd": "bash poker.sh \"4S AH AS 7C AD\" \"4S AH AS 8C AD\""
+    },
+    {
+      "name": "\"a straight beats three of a kind\"",
+      "cmd": "bash poker.sh \"4S 5H 4C 8D 4H\" \"3S 4D 2S 6D 5C\""
+    },
+    {
+      "name": "\"aces can end a straight (10 J Q K A)\"",
+      "cmd": "bash poker.sh \"4S 5H 4C 8D 4H\" \"10D JH QS KD AC\""
+    },
+    {
+      "name": "\"aces can start a straight (A 2 3 4 5)\"",
+      "cmd": "bash poker.sh \"4S 5H 4C 8D 4H\" \"4D AH 3S 2D 5C\""
+    },
+    {
+      "name": "\"both hands with a straight, tie goes to highest ranked card\"",
+      "cmd": "bash poker.sh \"4S 6C 7S 8D 5H\" \"5S 7H 8S 9D 6H\""
+    },
+    {
+      "name": "\"even though an ace is usually high, a 5-high straight is the lowest-scoring straight\"",
+      "cmd": "bash poker.sh \"2H 3C 4D 5D 6H\" \"4S AH 3S 2D 5H\""
+    },
+    {
+      "name": "\"flush beats a straight\"",
+      "cmd": "bash poker.sh \"4C 6H 7D 8D 5H\" \"2S 4S 5S 6S 7S\""
+    },
+    {
+      "name": "\"both hands have a flush, tie goes to high card, down to the last one if necessary\"",
+      "cmd": "bash poker.sh \"4H 7H 8H 9H 6H\" \"2S 4S 5S 6S 7S\""
+    },
+    {
+      "name": "\"full house beats a flush\"",
+      "cmd": "bash poker.sh \"3H 6H 7H 8H 5H\" \"4S 5H 4C 5D 4H\""
+    },
+    {
+      "name": "\"both hands have a full house, tie goes to highest-ranked triplet\"",
+      "cmd": "bash poker.sh \"4H 4S 4D 9S 9D\" \"5H 5S 5D 8S 8D\""
+    },
+    {
+      "name": "\"with multiple decks, both hands have a full house with the same triplet, tie goes to the pair\"",
+      "cmd": "bash poker.sh \"5H 5S 5D 9S 9D\" \"5H 5S 5D 8S 8D\""
+    },
+    {
+      "name": "\"four of a kind beats a full house\"",
+      "cmd": "bash poker.sh \"4S 5H 4D 5D 4H\" \"3S 3H 2S 3D 3C\""
+    },
+    {
+      "name": "\"both hands have four of a kind, tie goes to high quad\"",
+      "cmd": "bash poker.sh \"2S 2H 2C 8D 2D\" \"4S 5H 5S 5D 5C\""
+    },
+    {
+      "name": "\"with multiple decks, both hands with identical four of a kind, tie determined by kicker\"",
+      "cmd": "bash poker.sh \"3S 3H 2S 3D 3C\" \"3S 3H 4S 3D 3C\""
+    },
+    {
+      "name": "\"straight flush beats four of a kind\"",
+      "cmd": "bash poker.sh \"4S 5H 5S 5D 5C\" \"7S 8S 9S 6S 10S\""
+    },
+    {
+      "name": "\"both hands have straight flush, tie goes to highest-ranked card\"",
+      "cmd": "bash poker.sh \"4H 6H 7H 8H 5H\" \"5S 7S 8S 9S 6S\""
+    }
+  ]
+}

--- a/exercises/poker/.meta/config.json
+++ b/exercises/poker/.meta/config.json
@@ -4,115 +4,115 @@
   ],
   "tests": [
     {
-      "name": "\"single hand always wins\"",
+      "name": "single hand always wins",
       "cmd": "bash poker.sh \"4S 5S 7H 8D JC\""
     },
     {
-      "name": "\"highest card out of all hands wins\"",
+      "name": "highest card out of all hands wins",
       "cmd": "bash poker.sh \"4D 5S 6S 8D 3C\" \"2S 4C 7S 9H 10H\" \"3S 4S 5D 6H JH\""
     },
     {
-      "name": "\"a tie has multiple winners\"",
+      "name": "a tie has multiple winners",
       "cmd": "bash poker.sh \"4D 5S 6S 8D 3C\" \"2S 4C 7S 9H 10H\" \"3S 4S 5D 6H JH\" \"3H 4H 5C 6C JD\""
     },
     {
-      "name": "\"multiple hands with the same high cards, tie compares next highest ranked, down to last card\"",
+      "name": "multiple hands with the same high cards, tie compares next highest ranked, down to last card",
       "cmd": "bash poker.sh \"3S 5H 6S 8D 7H\" \"2S 5D 6D 8C 7S\""
     },
     {
-      "name": "\"one pair beats high card\"",
+      "name": "one pair beats high card",
       "cmd": "bash poker.sh \"4S 5H 6C 8D KH\" \"2S 4H 6S 4D JH\""
     },
     {
-      "name": "\"highest pair wins\"",
+      "name": "highest pair wins",
       "cmd": "bash poker.sh \"4S 2H 6S 2D JH\" \"2S 4H 6C 4D JD\""
     },
     {
-      "name": "\"two pairs beats one pair\"",
+      "name": "two pairs beats one pair",
       "cmd": "bash poker.sh \"2S 8H 6S 8D JH\" \"4S 5H 4C 8C 5C\""
     },
     {
-      "name": "\"both hands have two pairs, highest ranked pair wins\"",
+      "name": "both hands have two pairs, highest ranked pair wins",
       "cmd": "bash poker.sh \"2S 8H 2D 8D 3H\" \"4S 5H 4C 8S 5D\""
     },
     {
-      "name": "\"both hands have two pairs, with the same highest ranked pair, tie goes to low pair\"",
+      "name": "both hands have two pairs, with the same highest ranked pair, tie goes to low pair",
       "cmd": "bash poker.sh \"2S QS 2C QD JH\" \"JD QH JS 8D QC\""
     },
     {
-      "name": "\"both hands have two identically ranked pairs, tie goes to remaining card (kicker)\"",
+      "name": "both hands have two identically ranked pairs, tie goes to remaining card (kicker)",
       "cmd": "bash poker.sh \"JD QH JS 8D QC\" \"JS QS JC 2D QD\""
     },
     {
-      "name": "\"three of a kind beats two pair\"",
+      "name": "three of a kind beats two pair",
       "cmd": "bash poker.sh \"2S 8H 2H 8D JH\" \"4S 5H 4C 8S 4H\""
     },
     {
-      "name": "\"both hands have three of a kind, tie goes to highest ranked triplet\"",
+      "name": "both hands have three of a kind, tie goes to highest ranked triplet",
       "cmd": "bash poker.sh \"2S 2H 2C 8D JH\" \"4S AH AS 8C AD\""
     },
     {
-      "name": "\"with multiple decks, two players can have same three of a kind, ties go to highest remaining cards\"",
+      "name": "with multiple decks, two players can have same three of a kind, ties go to highest remaining cards",
       "cmd": "bash poker.sh \"4S AH AS 7C AD\" \"4S AH AS 8C AD\""
     },
     {
-      "name": "\"a straight beats three of a kind\"",
+      "name": "a straight beats three of a kind",
       "cmd": "bash poker.sh \"4S 5H 4C 8D 4H\" \"3S 4D 2S 6D 5C\""
     },
     {
-      "name": "\"aces can end a straight (10 J Q K A)\"",
+      "name": "aces can end a straight (10 J Q K A)",
       "cmd": "bash poker.sh \"4S 5H 4C 8D 4H\" \"10D JH QS KD AC\""
     },
     {
-      "name": "\"aces can start a straight (A 2 3 4 5)\"",
+      "name": "aces can start a straight (A 2 3 4 5)",
       "cmd": "bash poker.sh \"4S 5H 4C 8D 4H\" \"4D AH 3S 2D 5C\""
     },
     {
-      "name": "\"both hands with a straight, tie goes to highest ranked card\"",
+      "name": "both hands with a straight, tie goes to highest ranked card",
       "cmd": "bash poker.sh \"4S 6C 7S 8D 5H\" \"5S 7H 8S 9D 6H\""
     },
     {
-      "name": "\"even though an ace is usually high, a 5-high straight is the lowest-scoring straight\"",
+      "name": "even though an ace is usually high, a 5-high straight is the lowest-scoring straight",
       "cmd": "bash poker.sh \"2H 3C 4D 5D 6H\" \"4S AH 3S 2D 5H\""
     },
     {
-      "name": "\"flush beats a straight\"",
+      "name": "flush beats a straight",
       "cmd": "bash poker.sh \"4C 6H 7D 8D 5H\" \"2S 4S 5S 6S 7S\""
     },
     {
-      "name": "\"both hands have a flush, tie goes to high card, down to the last one if necessary\"",
+      "name": "both hands have a flush, tie goes to high card, down to the last one if necessary",
       "cmd": "bash poker.sh \"4H 7H 8H 9H 6H\" \"2S 4S 5S 6S 7S\""
     },
     {
-      "name": "\"full house beats a flush\"",
+      "name": "full house beats a flush",
       "cmd": "bash poker.sh \"3H 6H 7H 8H 5H\" \"4S 5H 4C 5D 4H\""
     },
     {
-      "name": "\"both hands have a full house, tie goes to highest-ranked triplet\"",
+      "name": "both hands have a full house, tie goes to highest-ranked triplet",
       "cmd": "bash poker.sh \"4H 4S 4D 9S 9D\" \"5H 5S 5D 8S 8D\""
     },
     {
-      "name": "\"with multiple decks, both hands have a full house with the same triplet, tie goes to the pair\"",
+      "name": "with multiple decks, both hands have a full house with the same triplet, tie goes to the pair",
       "cmd": "bash poker.sh \"5H 5S 5D 9S 9D\" \"5H 5S 5D 8S 8D\""
     },
     {
-      "name": "\"four of a kind beats a full house\"",
+      "name": "four of a kind beats a full house",
       "cmd": "bash poker.sh \"4S 5H 4D 5D 4H\" \"3S 3H 2S 3D 3C\""
     },
     {
-      "name": "\"both hands have four of a kind, tie goes to high quad\"",
+      "name": "both hands have four of a kind, tie goes to high quad",
       "cmd": "bash poker.sh \"2S 2H 2C 8D 2D\" \"4S 5H 5S 5D 5C\""
     },
     {
-      "name": "\"with multiple decks, both hands with identical four of a kind, tie determined by kicker\"",
+      "name": "with multiple decks, both hands with identical four of a kind, tie determined by kicker",
       "cmd": "bash poker.sh \"3S 3H 2S 3D 3C\" \"3S 3H 4S 3D 3C\""
     },
     {
-      "name": "\"straight flush beats four of a kind\"",
+      "name": "straight flush beats four of a kind",
       "cmd": "bash poker.sh \"4S 5H 5S 5D 5C\" \"7S 8S 9S 6S 10S\""
     },
     {
-      "name": "\"both hands have straight flush, tie goes to highest-ranked card\"",
+      "name": "both hands have straight flush, tie goes to highest-ranked card",
       "cmd": "bash poker.sh \"4H 6H 7H 8H 5H\" \"5S 7S 8S 9S 6S\""
     }
   ]

--- a/exercises/prime-factors/.meta/config.json
+++ b/exercises/prime-factors/.meta/config.json
@@ -4,31 +4,31 @@
   ],
   "tests": [
     {
-      "name": "\"no factors\"",
+      "name": "no factors",
       "cmd": "bash prime_factors.sh 1"
     },
     {
-      "name": "\"prime number\"",
+      "name": "prime number",
       "cmd": "bash prime_factors.sh 2"
     },
     {
-      "name": "\"square of a prime\"",
+      "name": "square of a prime",
       "cmd": "bash prime_factors.sh 9"
     },
     {
-      "name": "\"cube of a prime\"",
+      "name": "cube of a prime",
       "cmd": "bash prime_factors.sh 8"
     },
     {
-      "name": "\"product of primes and non-primes\"",
+      "name": "product of primes and non-primes",
       "cmd": "bash prime_factors.sh 12"
     },
     {
-      "name": "\"product of primes\"",
+      "name": "product of primes",
       "cmd": "bash prime_factors.sh 901255"
     },
     {
-      "name": "\"factors include a large prime\"",
+      "name": "factors include a large prime",
       "cmd": "bash prime_factors.sh 93819012551"
     }
   ]

--- a/exercises/prime-factors/.meta/config.json
+++ b/exercises/prime-factors/.meta/config.json
@@ -1,0 +1,35 @@
+{
+  "solution_files": [
+    "prime_factors.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"no factors\"",
+      "cmd": "bash prime_factors.sh 1"
+    },
+    {
+      "name": "\"prime number\"",
+      "cmd": "bash prime_factors.sh 2"
+    },
+    {
+      "name": "\"square of a prime\"",
+      "cmd": "bash prime_factors.sh 9"
+    },
+    {
+      "name": "\"cube of a prime\"",
+      "cmd": "bash prime_factors.sh 8"
+    },
+    {
+      "name": "\"product of primes and non-primes\"",
+      "cmd": "bash prime_factors.sh 12"
+    },
+    {
+      "name": "\"product of primes\"",
+      "cmd": "bash prime_factors.sh 901255"
+    },
+    {
+      "name": "\"factors include a large prime\"",
+      "cmd": "bash prime_factors.sh 93819012551"
+    }
+  ]
+}

--- a/exercises/protein-translation/.meta/config.json
+++ b/exercises/protein-translation/.meta/config.json
@@ -4,99 +4,99 @@
   ],
   "tests": [
     {
-      "name": "\"Methionine RNA sequence\"",
+      "name": "Methionine RNA sequence",
       "cmd": "bash protein_translation.sh \"AUG\""
     },
     {
-      "name": "\"Phenylalanine RNA sequence 1\"",
+      "name": "Phenylalanine RNA sequence 1",
       "cmd": "bash protein_translation.sh \"UUU\""
     },
     {
-      "name": "\"Phenylalanine RNA sequence 2\"",
+      "name": "Phenylalanine RNA sequence 2",
       "cmd": "bash protein_translation.sh \"UUC\""
     },
     {
-      "name": "\"Leucine RNA sequence 1\"",
+      "name": "Leucine RNA sequence 1",
       "cmd": "bash protein_translation.sh \"UUA\""
     },
     {
-      "name": "\"Leucine RNA sequence 2\"",
+      "name": "Leucine RNA sequence 2",
       "cmd": "bash protein_translation.sh \"UUG\""
     },
     {
-      "name": "\"Serine RNA sequence 1\"",
+      "name": "Serine RNA sequence 1",
       "cmd": "bash protein_translation.sh \"UCU\""
     },
     {
-      "name": "\"Serine RNA sequence 2\"",
+      "name": "Serine RNA sequence 2",
       "cmd": "bash protein_translation.sh \"UCC\""
     },
     {
-      "name": "\"Serine RNA sequence 3\"",
+      "name": "Serine RNA sequence 3",
       "cmd": "bash protein_translation.sh \"UCA\""
     },
     {
-      "name": "\"Serine RNA sequence 4\"",
+      "name": "Serine RNA sequence 4",
       "cmd": "bash protein_translation.sh \"UCG\""
     },
     {
-      "name": "\"Tyrosine RNA sequence 1\"",
+      "name": "Tyrosine RNA sequence 1",
       "cmd": "bash protein_translation.sh \"UAU\""
     },
     {
-      "name": "\"Tyrosine RNA sequence 2\"",
+      "name": "Tyrosine RNA sequence 2",
       "cmd": "bash protein_translation.sh \"UAC\""
     },
     {
-      "name": "\"Cysteine RNA sequence 1\"",
+      "name": "Cysteine RNA sequence 1",
       "cmd": "bash protein_translation.sh \"UGU\""
     },
     {
-      "name": "\"Cysteine RNA sequence 2\"",
+      "name": "Cysteine RNA sequence 2",
       "cmd": "bash protein_translation.sh \"UGC\""
     },
     {
-      "name": "\"Tryptophan RNA sequence\"",
+      "name": "Tryptophan RNA sequence",
       "cmd": "bash protein_translation.sh \"UGG\""
     },
     {
-      "name": "\"STOP codon RNA sequence 1\"",
+      "name": "STOP codon RNA sequence 1",
       "cmd": "bash protein_translation.sh \"UAA\""
     },
     {
-      "name": "\"STOP codon RNA sequence 2\"",
+      "name": "STOP codon RNA sequence 2",
       "cmd": "bash protein_translation.sh \"UAG\""
     },
     {
-      "name": "\"STOP codon RNA sequence 3\"",
+      "name": "STOP codon RNA sequence 3",
       "cmd": "bash protein_translation.sh \"UGA\""
     },
     {
-      "name": "\"Translate RNA strand into correct protein list\"",
+      "name": "Translate RNA strand into correct protein list",
       "cmd": "bash protein_translation.sh \"AUGUUUUGG\""
     },
     {
-      "name": "\"Translation stops if STOP codon at beginning of sequence\"",
+      "name": "Translation stops if STOP codon at beginning of sequence",
       "cmd": "bash protein_translation.sh \"UAGUGG\""
     },
     {
-      "name": "\"Translation stops if STOP codon at end of two-codon sequence\"",
+      "name": "Translation stops if STOP codon at end of two-codon sequence",
       "cmd": "bash protein_translation.sh \"UGGUAG\""
     },
     {
-      "name": "\"Translation stops if STOP codon at end of three-codon sequence\"",
+      "name": "Translation stops if STOP codon at end of three-codon sequence",
       "cmd": "bash protein_translation.sh \"AUGUUUUAA\""
     },
     {
-      "name": "\"Translation stops if STOP codon in middle of three-codon sequence\"",
+      "name": "Translation stops if STOP codon in middle of three-codon sequence",
       "cmd": "bash protein_translation.sh \"UGGUAGUGG\""
     },
     {
-      "name": "\"Translation stops if STOP codon in middle of six-codon sequence\"",
+      "name": "Translation stops if STOP codon in middle of six-codon sequence",
       "cmd": "bash protein_translation.sh \"UGGUGUUAUUAAUGGUUU\""
     },
     {
-      "name": "\"Error case\"",
+      "name": "Error case",
       "cmd": "bash protein_translation.sh \"UGG---AUG\""
     }
   ]

--- a/exercises/protein-translation/.meta/config.json
+++ b/exercises/protein-translation/.meta/config.json
@@ -1,0 +1,103 @@
+{
+  "solution_files": [
+    "protein_translation.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Methionine RNA sequence\"",
+      "cmd": "bash protein_translation.sh \"AUG\""
+    },
+    {
+      "name": "\"Phenylalanine RNA sequence 1\"",
+      "cmd": "bash protein_translation.sh \"UUU\""
+    },
+    {
+      "name": "\"Phenylalanine RNA sequence 2\"",
+      "cmd": "bash protein_translation.sh \"UUC\""
+    },
+    {
+      "name": "\"Leucine RNA sequence 1\"",
+      "cmd": "bash protein_translation.sh \"UUA\""
+    },
+    {
+      "name": "\"Leucine RNA sequence 2\"",
+      "cmd": "bash protein_translation.sh \"UUG\""
+    },
+    {
+      "name": "\"Serine RNA sequence 1\"",
+      "cmd": "bash protein_translation.sh \"UCU\""
+    },
+    {
+      "name": "\"Serine RNA sequence 2\"",
+      "cmd": "bash protein_translation.sh \"UCC\""
+    },
+    {
+      "name": "\"Serine RNA sequence 3\"",
+      "cmd": "bash protein_translation.sh \"UCA\""
+    },
+    {
+      "name": "\"Serine RNA sequence 4\"",
+      "cmd": "bash protein_translation.sh \"UCG\""
+    },
+    {
+      "name": "\"Tyrosine RNA sequence 1\"",
+      "cmd": "bash protein_translation.sh \"UAU\""
+    },
+    {
+      "name": "\"Tyrosine RNA sequence 2\"",
+      "cmd": "bash protein_translation.sh \"UAC\""
+    },
+    {
+      "name": "\"Cysteine RNA sequence 1\"",
+      "cmd": "bash protein_translation.sh \"UGU\""
+    },
+    {
+      "name": "\"Cysteine RNA sequence 2\"",
+      "cmd": "bash protein_translation.sh \"UGC\""
+    },
+    {
+      "name": "\"Tryptophan RNA sequence\"",
+      "cmd": "bash protein_translation.sh \"UGG\""
+    },
+    {
+      "name": "\"STOP codon RNA sequence 1\"",
+      "cmd": "bash protein_translation.sh \"UAA\""
+    },
+    {
+      "name": "\"STOP codon RNA sequence 2\"",
+      "cmd": "bash protein_translation.sh \"UAG\""
+    },
+    {
+      "name": "\"STOP codon RNA sequence 3\"",
+      "cmd": "bash protein_translation.sh \"UGA\""
+    },
+    {
+      "name": "\"Translate RNA strand into correct protein list\"",
+      "cmd": "bash protein_translation.sh \"AUGUUUUGG\""
+    },
+    {
+      "name": "\"Translation stops if STOP codon at beginning of sequence\"",
+      "cmd": "bash protein_translation.sh \"UAGUGG\""
+    },
+    {
+      "name": "\"Translation stops if STOP codon at end of two-codon sequence\"",
+      "cmd": "bash protein_translation.sh \"UGGUAG\""
+    },
+    {
+      "name": "\"Translation stops if STOP codon at end of three-codon sequence\"",
+      "cmd": "bash protein_translation.sh \"AUGUUUUAA\""
+    },
+    {
+      "name": "\"Translation stops if STOP codon in middle of three-codon sequence\"",
+      "cmd": "bash protein_translation.sh \"UGGUAGUGG\""
+    },
+    {
+      "name": "\"Translation stops if STOP codon in middle of six-codon sequence\"",
+      "cmd": "bash protein_translation.sh \"UGGUGUUAUUAAUGGUUU\""
+    },
+    {
+      "name": "\"Error case\"",
+      "cmd": "bash protein_translation.sh \"UGG---AUG\""
+    }
+  ]
+}

--- a/exercises/proverb/.meta/config.json
+++ b/exercises/proverb/.meta/config.json
@@ -4,35 +4,35 @@
   ],
   "tests": [
     {
-      "name": "\"zero pieces\"",
+      "name": "zero pieces",
       "cmd": "bash proverb.sh"
     },
     {
-      "name": "\"one piece\"",
+      "name": "one piece",
       "cmd": "bash proverb.sh nail"
     },
     {
-      "name": "\"two pieces\"",
+      "name": "two pieces",
       "cmd": "bash proverb.sh nail shoe"
     },
     {
-      "name": "\"three pieces\"",
+      "name": "three pieces",
       "cmd": "bash proverb.sh nail shoe horse"
     },
     {
-      "name": "\"full proverb\"",
+      "name": "full proverb",
       "cmd": "bash proverb.sh nail shoe horse rider message battle kingdom"
     },
     {
-      "name": "\"four pieces modernized\"",
+      "name": "four pieces modernized",
       "cmd": "bash proverb.sh pin gun soldier battle"
     },
     {
-      "name": "\"items with whitespace\"",
+      "name": "items with whitespace",
       "cmd": "bash proverb.sh \"rusty nail\" \"horse shoe\""
     },
     {
-      "name": "\"shell globbing character\"",
+      "name": "shell globbing character",
       "cmd": "bash proverb.sh quotes \"*\""
     }
   ]

--- a/exercises/proverb/.meta/config.json
+++ b/exercises/proverb/.meta/config.json
@@ -1,0 +1,39 @@
+{
+  "solution_files": [
+    "proverb.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"zero pieces\"",
+      "cmd": "bash proverb.sh"
+    },
+    {
+      "name": "\"one piece\"",
+      "cmd": "bash proverb.sh nail"
+    },
+    {
+      "name": "\"two pieces\"",
+      "cmd": "bash proverb.sh nail shoe"
+    },
+    {
+      "name": "\"three pieces\"",
+      "cmd": "bash proverb.sh nail shoe horse"
+    },
+    {
+      "name": "\"full proverb\"",
+      "cmd": "bash proverb.sh nail shoe horse rider message battle kingdom"
+    },
+    {
+      "name": "\"four pieces modernized\"",
+      "cmd": "bash proverb.sh pin gun soldier battle"
+    },
+    {
+      "name": "\"items with whitespace\"",
+      "cmd": "bash proverb.sh \"rusty nail\" \"horse shoe\""
+    },
+    {
+      "name": "\"shell globbing character\"",
+      "cmd": "bash proverb.sh quotes \"*\""
+    }
+  ]
+}

--- a/exercises/pythagorean-triplet/.meta/config.json
+++ b/exercises/pythagorean-triplet/.meta/config.json
@@ -4,27 +4,27 @@
   ],
   "tests": [
     {
-      "name": "\"triplets whose sum is 12\"",
+      "name": "triplets whose sum is 12",
       "cmd": "bash pythagorean_triplet.sh 12"
     },
     {
-      "name": "\"triplets whose sum is 108\"",
+      "name": "triplets whose sum is 108",
       "cmd": "bash pythagorean_triplet.sh 108"
     },
     {
-      "name": "\"triplets whose sum is 1000\"",
+      "name": "triplets whose sum is 1000",
       "cmd": "bash pythagorean_triplet.sh 1000"
     },
     {
-      "name": "\"no matching triplets for 1001\"",
+      "name": "no matching triplets for 1001",
       "cmd": "bash pythagorean_triplet.sh 1001"
     },
     {
-      "name": "\"returns all matching triplets\"",
+      "name": "returns all matching triplets",
       "cmd": "bash pythagorean_triplet.sh 90"
     },
     {
-      "name": "\"several matching triplets\"",
+      "name": "several matching triplets",
       "cmd": "bash pythagorean_triplet.sh 840"
     }
   ]

--- a/exercises/pythagorean-triplet/.meta/config.json
+++ b/exercises/pythagorean-triplet/.meta/config.json
@@ -1,0 +1,31 @@
+{
+  "solution_files": [
+    "pythagorean_triplet.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"triplets whose sum is 12\"",
+      "cmd": "bash pythagorean_triplet.sh 12"
+    },
+    {
+      "name": "\"triplets whose sum is 108\"",
+      "cmd": "bash pythagorean_triplet.sh 108"
+    },
+    {
+      "name": "\"triplets whose sum is 1000\"",
+      "cmd": "bash pythagorean_triplet.sh 1000"
+    },
+    {
+      "name": "\"no matching triplets for 1001\"",
+      "cmd": "bash pythagorean_triplet.sh 1001"
+    },
+    {
+      "name": "\"returns all matching triplets\"",
+      "cmd": "bash pythagorean_triplet.sh 90"
+    },
+    {
+      "name": "\"several matching triplets\"",
+      "cmd": "bash pythagorean_triplet.sh 840"
+    }
+  ]
+}

--- a/exercises/queen-attack/.meta/config.json
+++ b/exercises/queen-attack/.meta/config.json
@@ -1,0 +1,55 @@
+{
+  "solution_files": [
+    "queen_attack.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"queen must have positive row\"",
+      "cmd": "bash queen_attack.sh -w -2,2 -b 7,7"
+    },
+    {
+      "name": "\"queen must have row on board\"",
+      "cmd": "bash queen_attack.sh -w 8,4 -b 7,7"
+    },
+    {
+      "name": "\"queen must have positive column\"",
+      "cmd": "bash queen_attack.sh -w 2,-2 -b 7,7"
+    },
+    {
+      "name": "\"queen must have column on board\"",
+      "cmd": "bash queen_attack.sh -w 4,8 -b 7,7"
+    },
+    {
+      "name": "\"same position\"",
+      "cmd": "bash queen_attack.sh -w 7,7 -b 7,7"
+    },
+    {
+      "name": "\"can not attack\"",
+      "cmd": "bash queen_attack.sh -w 2,4 -b 6,6"
+    },
+    {
+      "name": "\"can attack on same row\"",
+      "cmd": "bash queen_attack.sh -w 2,4 -b 2,6"
+    },
+    {
+      "name": "\"can attack on same column\"",
+      "cmd": "bash queen_attack.sh -w 4,5 -b 2,5"
+    },
+    {
+      "name": "\"can attack on first diagonal\"",
+      "cmd": "bash queen_attack.sh -w 2,2 -b 0,4"
+    },
+    {
+      "name": "\"can attack on second diagonal\"",
+      "cmd": "bash queen_attack.sh -w 2,2 -b 3,1"
+    },
+    {
+      "name": "\"can attack on third diagonal\"",
+      "cmd": "bash queen_attack.sh -w 2,2 -b 1,1"
+    },
+    {
+      "name": "\"can attack on fourth diagonal\"",
+      "cmd": "bash queen_attack.sh -w 1,7 -b 0,6"
+    }
+  ]
+}

--- a/exercises/queen-attack/.meta/config.json
+++ b/exercises/queen-attack/.meta/config.json
@@ -4,51 +4,51 @@
   ],
   "tests": [
     {
-      "name": "\"queen must have positive row\"",
+      "name": "queen must have positive row",
       "cmd": "bash queen_attack.sh -w -2,2 -b 7,7"
     },
     {
-      "name": "\"queen must have row on board\"",
+      "name": "queen must have row on board",
       "cmd": "bash queen_attack.sh -w 8,4 -b 7,7"
     },
     {
-      "name": "\"queen must have positive column\"",
+      "name": "queen must have positive column",
       "cmd": "bash queen_attack.sh -w 2,-2 -b 7,7"
     },
     {
-      "name": "\"queen must have column on board\"",
+      "name": "queen must have column on board",
       "cmd": "bash queen_attack.sh -w 4,8 -b 7,7"
     },
     {
-      "name": "\"same position\"",
+      "name": "same position",
       "cmd": "bash queen_attack.sh -w 7,7 -b 7,7"
     },
     {
-      "name": "\"can not attack\"",
+      "name": "can not attack",
       "cmd": "bash queen_attack.sh -w 2,4 -b 6,6"
     },
     {
-      "name": "\"can attack on same row\"",
+      "name": "can attack on same row",
       "cmd": "bash queen_attack.sh -w 2,4 -b 2,6"
     },
     {
-      "name": "\"can attack on same column\"",
+      "name": "can attack on same column",
       "cmd": "bash queen_attack.sh -w 4,5 -b 2,5"
     },
     {
-      "name": "\"can attack on first diagonal\"",
+      "name": "can attack on first diagonal",
       "cmd": "bash queen_attack.sh -w 2,2 -b 0,4"
     },
     {
-      "name": "\"can attack on second diagonal\"",
+      "name": "can attack on second diagonal",
       "cmd": "bash queen_attack.sh -w 2,2 -b 3,1"
     },
     {
-      "name": "\"can attack on third diagonal\"",
+      "name": "can attack on third diagonal",
       "cmd": "bash queen_attack.sh -w 2,2 -b 1,1"
     },
     {
-      "name": "\"can attack on fourth diagonal\"",
+      "name": "can attack on fourth diagonal",
       "cmd": "bash queen_attack.sh -w 1,7 -b 0,6"
     }
   ]

--- a/exercises/rail-fence-cipher/.meta/config.json
+++ b/exercises/rail-fence-cipher/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "rail_fence_cipher.sh"
+  ],
+  "tests": [
+    {
+      "name": "empty text",
+      "cmd": "bash rail_fence_cipher.sh -e 2 \"\""
+    },
+    {
+      "name": "encode with two rails",
+      "cmd": "bash rail_fence_cipher.sh -e 2 \"XOXOXOXOXOXOXOXOXO\""
+    },
+    {
+      "name": "encode with three rails",
+      "cmd": "bash rail_fence_cipher.sh -e 3 \"WEAREDISCOVEREDFLEEATONCE\""
+    },
+    {
+      "name": "encode with ending in the middle",
+      "cmd": "bash rail_fence_cipher.sh -e 4 \"EXERCISES\""
+    },
+    {
+      "name": "encode with more rails than text",
+      "cmd": "bash rail_fence_cipher.sh -e 10 \"hello\""
+    },
+    {
+      "name": "decode with three rails",
+      "cmd": "bash rail_fence_cipher.sh -d 3 \"TEITELHDVLSNHDTISEIIEA\""
+    },
+    {
+      "name": "decode with five rails",
+      "cmd": "bash rail_fence_cipher.sh -d 5 \"EIEXMSMESAORIWSCE\""
+    },
+    {
+      "name": "decode with six rails",
+      "cmd": "bash rail_fence_cipher.sh -d 6 \"133714114238148966225439541018335470986172518171757571896261\""
+    },
+    {
+      "name": "decode with more rails than text",
+      "cmd": "bash rail_fence_cipher.sh -d 10 \"hello\""
+    },
+    {
+      "name": "decode the encoded text yields the original",
+      "cmd": "bash rail_fence_cipher.sh -e $rails \"$plaintext\""
+    },
+    {
+      "name": "no options",
+      "cmd": "bash rail_fence_cipher.sh"
+    },
+    {
+      "name": "zero rails",
+      "cmd": "bash rail_fence_cipher.sh -e 0 abc"
+    },
+    {
+      "name": "negative rails",
+      "cmd": "bash rail_fence_cipher.sh -d -2 abc"
+    }
+  ]
+}

--- a/exercises/raindrops/.meta/config.json
+++ b/exercises/raindrops/.meta/config.json
@@ -1,0 +1,79 @@
+{
+  "solution_files": [
+    "raindrops.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"the sound for 1 is 1\"",
+      "cmd": "bash raindrops.sh 1"
+    },
+    {
+      "name": "\"the sound for 3 is Pling\"",
+      "cmd": "bash raindrops.sh 3"
+    },
+    {
+      "name": "\"the sound for 5 is Plang\"",
+      "cmd": "bash raindrops.sh 5"
+    },
+    {
+      "name": "\"the sound for 7 is Plong\"",
+      "cmd": "bash raindrops.sh 7"
+    },
+    {
+      "name": "\"the sound for 6 is Pling as it has a factor 3\"",
+      "cmd": "bash raindrops.sh 6"
+    },
+    {
+      "name": "\"2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base\"",
+      "cmd": "bash raindrops.sh 8"
+    },
+    {
+      "name": "\"the sound for 9 is Pling as it has a factor 3\"",
+      "cmd": "bash raindrops.sh 9"
+    },
+    {
+      "name": "\"the sound for 10 is Plang as it has a factor 5\"",
+      "cmd": "bash raindrops.sh 10"
+    },
+    {
+      "name": "\"the sound for 14 is Plong as it has a factor of 7\"",
+      "cmd": "bash raindrops.sh 14"
+    },
+    {
+      "name": "\"the sound for 15 is PlingPlang as it has factors 3 and 5\"",
+      "cmd": "bash raindrops.sh 15"
+    },
+    {
+      "name": "\"the sound for 21 is PlingPlong as it has factors 3 and 7\"",
+      "cmd": "bash raindrops.sh 21"
+    },
+    {
+      "name": "\"the sound for 25 is Plang as it has a factor 5\"",
+      "cmd": "bash raindrops.sh 25"
+    },
+    {
+      "name": "\"the sound for 27 is Pling as it has a factor 3\"",
+      "cmd": "bash raindrops.sh 27"
+    },
+    {
+      "name": "\"the sound for 35 is PlangPlong as it has factors 5 and 7\"",
+      "cmd": "bash raindrops.sh 35"
+    },
+    {
+      "name": "\"the sound for 49 is Plong as it has a factor 7\"",
+      "cmd": "bash raindrops.sh 49"
+    },
+    {
+      "name": "\"the sound for 52 is 52\"",
+      "cmd": "bash raindrops.sh 52"
+    },
+    {
+      "name": "\"the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7\"",
+      "cmd": "bash raindrops.sh 105"
+    },
+    {
+      "name": "\"the sound for 3125 is Plang as it has a factor 5\"",
+      "cmd": "bash raindrops.sh 3125"
+    }
+  ]
+}

--- a/exercises/raindrops/.meta/config.json
+++ b/exercises/raindrops/.meta/config.json
@@ -4,75 +4,75 @@
   ],
   "tests": [
     {
-      "name": "\"the sound for 1 is 1\"",
+      "name": "the sound for 1 is 1",
       "cmd": "bash raindrops.sh 1"
     },
     {
-      "name": "\"the sound for 3 is Pling\"",
+      "name": "the sound for 3 is Pling",
       "cmd": "bash raindrops.sh 3"
     },
     {
-      "name": "\"the sound for 5 is Plang\"",
+      "name": "the sound for 5 is Plang",
       "cmd": "bash raindrops.sh 5"
     },
     {
-      "name": "\"the sound for 7 is Plong\"",
+      "name": "the sound for 7 is Plong",
       "cmd": "bash raindrops.sh 7"
     },
     {
-      "name": "\"the sound for 6 is Pling as it has a factor 3\"",
+      "name": "the sound for 6 is Pling as it has a factor 3",
       "cmd": "bash raindrops.sh 6"
     },
     {
-      "name": "\"2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base\"",
+      "name": "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base",
       "cmd": "bash raindrops.sh 8"
     },
     {
-      "name": "\"the sound for 9 is Pling as it has a factor 3\"",
+      "name": "the sound for 9 is Pling as it has a factor 3",
       "cmd": "bash raindrops.sh 9"
     },
     {
-      "name": "\"the sound for 10 is Plang as it has a factor 5\"",
+      "name": "the sound for 10 is Plang as it has a factor 5",
       "cmd": "bash raindrops.sh 10"
     },
     {
-      "name": "\"the sound for 14 is Plong as it has a factor of 7\"",
+      "name": "the sound for 14 is Plong as it has a factor of 7",
       "cmd": "bash raindrops.sh 14"
     },
     {
-      "name": "\"the sound for 15 is PlingPlang as it has factors 3 and 5\"",
+      "name": "the sound for 15 is PlingPlang as it has factors 3 and 5",
       "cmd": "bash raindrops.sh 15"
     },
     {
-      "name": "\"the sound for 21 is PlingPlong as it has factors 3 and 7\"",
+      "name": "the sound for 21 is PlingPlong as it has factors 3 and 7",
       "cmd": "bash raindrops.sh 21"
     },
     {
-      "name": "\"the sound for 25 is Plang as it has a factor 5\"",
+      "name": "the sound for 25 is Plang as it has a factor 5",
       "cmd": "bash raindrops.sh 25"
     },
     {
-      "name": "\"the sound for 27 is Pling as it has a factor 3\"",
+      "name": "the sound for 27 is Pling as it has a factor 3",
       "cmd": "bash raindrops.sh 27"
     },
     {
-      "name": "\"the sound for 35 is PlangPlong as it has factors 5 and 7\"",
+      "name": "the sound for 35 is PlangPlong as it has factors 5 and 7",
       "cmd": "bash raindrops.sh 35"
     },
     {
-      "name": "\"the sound for 49 is Plong as it has a factor 7\"",
+      "name": "the sound for 49 is Plong as it has a factor 7",
       "cmd": "bash raindrops.sh 49"
     },
     {
-      "name": "\"the sound for 52 is 52\"",
+      "name": "the sound for 52 is 52",
       "cmd": "bash raindrops.sh 52"
     },
     {
-      "name": "\"the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7\"",
+      "name": "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7",
       "cmd": "bash raindrops.sh 105"
     },
     {
-      "name": "\"the sound for 3125 is Plang as it has a factor 5\"",
+      "name": "the sound for 3125 is Plang as it has a factor 5",
       "cmd": "bash raindrops.sh 3125"
     }
   ]

--- a/exercises/rational-numbers/.meta/config.json
+++ b/exercises/rational-numbers/.meta/config.json
@@ -4,159 +4,159 @@
   ],
   "tests": [
     {
-      "name": "\"Add two positive rational numbers\"",
+      "name": "Add two positive rational numbers",
       "cmd": "bash rational_numbers.sh \"+\" \"1/2\" \"2/3\""
     },
     {
-      "name": "\"Add a positive rational number and a negative rational number\"",
+      "name": "Add a positive rational number and a negative rational number",
       "cmd": "bash rational_numbers.sh \"+\" \"1/2\" \"-2/3\""
     },
     {
-      "name": "\"Add two negative rational numbers\"",
+      "name": "Add two negative rational numbers",
       "cmd": "bash rational_numbers.sh \"+\" \"-1/2\" \"-2/3\""
     },
     {
-      "name": "\"Add a rational number to its additive inverse\"",
+      "name": "Add a rational number to its additive inverse",
       "cmd": "bash rational_numbers.sh \"+\" \"1/2\" \"-1/2\""
     },
     {
-      "name": "\"Subtract two positive rational numbers\"",
+      "name": "Subtract two positive rational numbers",
       "cmd": "bash rational_numbers.sh \"-\" \"1/2\" \"2/3\""
     },
     {
-      "name": "\"Subtract a positive rational number and a negative rational number\"",
+      "name": "Subtract a positive rational number and a negative rational number",
       "cmd": "bash rational_numbers.sh \"-\" \"1/2\" \"-2/3\""
     },
     {
-      "name": "\"Subtract two negative rational numbers\"",
+      "name": "Subtract two negative rational numbers",
       "cmd": "bash rational_numbers.sh \"-\" \"-1/2\" \"-2/3\""
     },
     {
-      "name": "\"Subtract a rational number from itself\"",
+      "name": "Subtract a rational number from itself",
       "cmd": "bash rational_numbers.sh \"-\" \"1/2\" \"1/2\""
     },
     {
-      "name": "\"Multiply two positive rational numbers\"",
+      "name": "Multiply two positive rational numbers",
       "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"2/3\""
     },
     {
-      "name": "\"Multiply a negative rational number by a positive rational number\"",
+      "name": "Multiply a negative rational number by a positive rational number",
       "cmd": "bash rational_numbers.sh \"*\" \"-1/2\" \"2/3\""
     },
     {
-      "name": "\"Multiply two negative rational numbers\"",
+      "name": "Multiply two negative rational numbers",
       "cmd": "bash rational_numbers.sh \"*\" \"-1/2\" \"-2/3\""
     },
     {
-      "name": "\"Multiply a rational number by its reciprocal\"",
+      "name": "Multiply a rational number by its reciprocal",
       "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"2/1\""
     },
     {
-      "name": "\"Multiply a rational number by 1\"",
+      "name": "Multiply a rational number by 1",
       "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"1/1\""
     },
     {
-      "name": "\"Multiply a rational number by 0\"",
+      "name": "Multiply a rational number by 0",
       "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"0/1\""
     },
     {
-      "name": "\"Divide two positive rational numbers\"",
+      "name": "Divide two positive rational numbers",
       "cmd": "bash rational_numbers.sh \"/\" \"1/2\" \"2/3\""
     },
     {
-      "name": "\"Divide a positive rational number by a negative rational number\"",
+      "name": "Divide a positive rational number by a negative rational number",
       "cmd": "bash rational_numbers.sh \"/\" \"1/2\" \"-2/3\""
     },
     {
-      "name": "\"Divide two negative rational numbers\"",
+      "name": "Divide two negative rational numbers",
       "cmd": "bash rational_numbers.sh \"/\" \"-1/2\" \"-2/3\""
     },
     {
-      "name": "\"Divide a rational number by 1\"",
+      "name": "Divide a rational number by 1",
       "cmd": "bash rational_numbers.sh \"/\" \"1/2\" \"1/1\""
     },
     {
-      "name": "\"Absolute value of a positive rational number\"",
+      "name": "Absolute value of a positive rational number",
       "cmd": "bash rational_numbers.sh \"abs\" \"1/2\""
     },
     {
-      "name": "\"Absolute value of a positive rational number with negative numerator and denominator\"",
+      "name": "Absolute value of a positive rational number with negative numerator and denominator",
       "cmd": "bash rational_numbers.sh \"abs\" \"-1/-2\""
     },
     {
-      "name": "\"Absolute value of a negative rational number\"",
+      "name": "Absolute value of a negative rational number",
       "cmd": "bash rational_numbers.sh \"abs\" \"-1/2\""
     },
     {
-      "name": "\"Absolute value of a negative rational number with negative denominator\"",
+      "name": "Absolute value of a negative rational number with negative denominator",
       "cmd": "bash rational_numbers.sh \"abs\" \"1/-2\""
     },
     {
-      "name": "\"Absolute value of zero\"",
+      "name": "Absolute value of zero",
       "cmd": "bash rational_numbers.sh \"abs\" \"0/1\""
     },
     {
-      "name": "\"Raise a positive rational number to a positive integer power\"",
+      "name": "Raise a positive rational number to a positive integer power",
       "cmd": "bash rational_numbers.sh \"pow\" \"1/2\" 3"
     },
     {
-      "name": "\"Raise a negative rational number to a positive integer power\"",
+      "name": "Raise a negative rational number to a positive integer power",
       "cmd": "bash rational_numbers.sh \"pow\" \"-1/2\" 3"
     },
     {
-      "name": "\"Raise zero to an integer power\"",
+      "name": "Raise zero to an integer power",
       "cmd": "bash rational_numbers.sh \"pow\" \"0/1\" 5"
     },
     {
-      "name": "\"Raise one to an integer power\"",
+      "name": "Raise one to an integer power",
       "cmd": "bash rational_numbers.sh \"pow\" \"1/1\" 4"
     },
     {
-      "name": "\"Raise a positive rational number to the power of zero\"",
+      "name": "Raise a positive rational number to the power of zero",
       "cmd": "bash rational_numbers.sh \"pow\" \"1/2\" 0"
     },
     {
-      "name": "\"Raise a negative rational number to the power of zero\"",
+      "name": "Raise a negative rational number to the power of zero",
       "cmd": "bash rational_numbers.sh \"pow\" \"-1/2\" 0"
     },
     {
-      "name": "\"Raise a real number to a positive rational number\"",
+      "name": "Raise a real number to a positive rational number",
       "cmd": "bash rational_numbers.sh \"rpow\" 8 \"4/3\""
     },
     {
-      "name": "\"Raise a real number to a negative rational number\"",
+      "name": "Raise a real number to a negative rational number",
       "cmd": "bash rational_numbers.sh \"rpow\" 9 \"-1/2\""
     },
     {
-      "name": "\"Raise a real number to a zero rational number\"",
+      "name": "Raise a real number to a zero rational number",
       "cmd": "bash rational_numbers.sh \"rpow\" 2 \"0/1\""
     },
     {
-      "name": "\"Reduce a positive rational number to lowest terms\"",
+      "name": "Reduce a positive rational number to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"2/4\""
     },
     {
-      "name": "\"Reduce a negative rational number to lowest terms\"",
+      "name": "Reduce a negative rational number to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"-4/6\""
     },
     {
-      "name": "\"Reduce a rational number with a negative denominator to lowest terms\"",
+      "name": "Reduce a rational number with a negative denominator to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"3/-9\""
     },
     {
-      "name": "\"Reduce zero to lowest terms\"",
+      "name": "Reduce zero to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"0/6\""
     },
     {
-      "name": "\"Reduce an integer to lowest terms\"",
+      "name": "Reduce an integer to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"-14/7\""
     },
     {
-      "name": "\"Reduce one to lowest terms\"",
+      "name": "Reduce one to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"13/13\""
     },
     {
-      "name": "\"Reduce zero to lowest terms\"",
+      "name": "Reduce zero to lowest terms",
       "cmd": "bash rational_numbers.sh \"reduce\" \"0/13\""
     }
   ]

--- a/exercises/rational-numbers/.meta/config.json
+++ b/exercises/rational-numbers/.meta/config.json
@@ -1,0 +1,163 @@
+{
+  "solution_files": [
+    "rational_numbers.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Add two positive rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"+\" \"1/2\" \"2/3\""
+    },
+    {
+      "name": "\"Add a positive rational number and a negative rational number\"",
+      "cmd": "bash rational_numbers.sh \"+\" \"1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Add two negative rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"+\" \"-1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Add a rational number to its additive inverse\"",
+      "cmd": "bash rational_numbers.sh \"+\" \"1/2\" \"-1/2\""
+    },
+    {
+      "name": "\"Subtract two positive rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"-\" \"1/2\" \"2/3\""
+    },
+    {
+      "name": "\"Subtract a positive rational number and a negative rational number\"",
+      "cmd": "bash rational_numbers.sh \"-\" \"1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Subtract two negative rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"-\" \"-1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Subtract a rational number from itself\"",
+      "cmd": "bash rational_numbers.sh \"-\" \"1/2\" \"1/2\""
+    },
+    {
+      "name": "\"Multiply two positive rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"2/3\""
+    },
+    {
+      "name": "\"Multiply a negative rational number by a positive rational number\"",
+      "cmd": "bash rational_numbers.sh \"*\" \"-1/2\" \"2/3\""
+    },
+    {
+      "name": "\"Multiply two negative rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"*\" \"-1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Multiply a rational number by its reciprocal\"",
+      "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"2/1\""
+    },
+    {
+      "name": "\"Multiply a rational number by 1\"",
+      "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"1/1\""
+    },
+    {
+      "name": "\"Multiply a rational number by 0\"",
+      "cmd": "bash rational_numbers.sh \"*\" \"1/2\" \"0/1\""
+    },
+    {
+      "name": "\"Divide two positive rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"/\" \"1/2\" \"2/3\""
+    },
+    {
+      "name": "\"Divide a positive rational number by a negative rational number\"",
+      "cmd": "bash rational_numbers.sh \"/\" \"1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Divide two negative rational numbers\"",
+      "cmd": "bash rational_numbers.sh \"/\" \"-1/2\" \"-2/3\""
+    },
+    {
+      "name": "\"Divide a rational number by 1\"",
+      "cmd": "bash rational_numbers.sh \"/\" \"1/2\" \"1/1\""
+    },
+    {
+      "name": "\"Absolute value of a positive rational number\"",
+      "cmd": "bash rational_numbers.sh \"abs\" \"1/2\""
+    },
+    {
+      "name": "\"Absolute value of a positive rational number with negative numerator and denominator\"",
+      "cmd": "bash rational_numbers.sh \"abs\" \"-1/-2\""
+    },
+    {
+      "name": "\"Absolute value of a negative rational number\"",
+      "cmd": "bash rational_numbers.sh \"abs\" \"-1/2\""
+    },
+    {
+      "name": "\"Absolute value of a negative rational number with negative denominator\"",
+      "cmd": "bash rational_numbers.sh \"abs\" \"1/-2\""
+    },
+    {
+      "name": "\"Absolute value of zero\"",
+      "cmd": "bash rational_numbers.sh \"abs\" \"0/1\""
+    },
+    {
+      "name": "\"Raise a positive rational number to a positive integer power\"",
+      "cmd": "bash rational_numbers.sh \"pow\" \"1/2\" 3"
+    },
+    {
+      "name": "\"Raise a negative rational number to a positive integer power\"",
+      "cmd": "bash rational_numbers.sh \"pow\" \"-1/2\" 3"
+    },
+    {
+      "name": "\"Raise zero to an integer power\"",
+      "cmd": "bash rational_numbers.sh \"pow\" \"0/1\" 5"
+    },
+    {
+      "name": "\"Raise one to an integer power\"",
+      "cmd": "bash rational_numbers.sh \"pow\" \"1/1\" 4"
+    },
+    {
+      "name": "\"Raise a positive rational number to the power of zero\"",
+      "cmd": "bash rational_numbers.sh \"pow\" \"1/2\" 0"
+    },
+    {
+      "name": "\"Raise a negative rational number to the power of zero\"",
+      "cmd": "bash rational_numbers.sh \"pow\" \"-1/2\" 0"
+    },
+    {
+      "name": "\"Raise a real number to a positive rational number\"",
+      "cmd": "bash rational_numbers.sh \"rpow\" 8 \"4/3\""
+    },
+    {
+      "name": "\"Raise a real number to a negative rational number\"",
+      "cmd": "bash rational_numbers.sh \"rpow\" 9 \"-1/2\""
+    },
+    {
+      "name": "\"Raise a real number to a zero rational number\"",
+      "cmd": "bash rational_numbers.sh \"rpow\" 2 \"0/1\""
+    },
+    {
+      "name": "\"Reduce a positive rational number to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"2/4\""
+    },
+    {
+      "name": "\"Reduce a negative rational number to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"-4/6\""
+    },
+    {
+      "name": "\"Reduce a rational number with a negative denominator to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"3/-9\""
+    },
+    {
+      "name": "\"Reduce zero to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"0/6\""
+    },
+    {
+      "name": "\"Reduce an integer to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"-14/7\""
+    },
+    {
+      "name": "\"Reduce one to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"13/13\""
+    },
+    {
+      "name": "\"Reduce zero to lowest terms\"",
+      "cmd": "bash rational_numbers.sh \"reduce\" \"0/13\""
+    }
+  ]
+}

--- a/exercises/rectangles/.meta/config.json
+++ b/exercises/rectangles/.meta/config.json
@@ -4,63 +4,63 @@
   ],
   "tests": [
     {
-      "name": "\"no rows\"",
+      "name": "no rows",
       "cmd": "bash rectangles.sh"
     },
     {
-      "name": "\"no columns\"",
+      "name": "no columns",
       "cmd": "bash rectangles.sh <<<\"\""
     },
     {
-      "name": "\"no rectangles\"",
+      "name": "no rectangles",
       "cmd": "bash rectangles.sh <<<\" \""
     },
     {
-      "name": "\"one rectangle\"",
+      "name": "one rectangle",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"two rectangles without shared parts\"",
+      "name": "two rectangles without shared parts",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"five rectangles with shared parts\"",
+      "name": "five rectangles with shared parts",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"rectangle of height 1 is counted\"",
+      "name": "rectangle of height 1 is counted",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"rectangle of width 1 is counted\"",
+      "name": "rectangle of width 1 is counted",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"1x1 square is counted\"",
+      "name": "1x1 square is counted",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"only complete rectangles are counted\"",
+      "name": "only complete rectangles are counted",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"rectangles can be of different sizes\"",
+      "name": "rectangles can be of different sizes",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"corner is required for a rectangle to be complete\"",
+      "name": "corner is required for a rectangle to be complete",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"large input with many rectangles\"",
+      "name": "large input with many rectangles",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"nested rectangles\"",
+      "name": "nested rectangles",
       "cmd": "bash rectangles.sh <<INPUT"
     },
     {
-      "name": "\"side by side rectangles\"",
+      "name": "side by side rectangles",
       "cmd": "bash rectangles.sh <<INPUT"
     }
   ]

--- a/exercises/rectangles/.meta/config.json
+++ b/exercises/rectangles/.meta/config.json
@@ -1,0 +1,67 @@
+{
+  "solution_files": [
+    "rectangles.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"no rows\"",
+      "cmd": "bash rectangles.sh"
+    },
+    {
+      "name": "\"no columns\"",
+      "cmd": "bash rectangles.sh <<<\"\""
+    },
+    {
+      "name": "\"no rectangles\"",
+      "cmd": "bash rectangles.sh <<<\" \""
+    },
+    {
+      "name": "\"one rectangle\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"two rectangles without shared parts\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"five rectangles with shared parts\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"rectangle of height 1 is counted\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"rectangle of width 1 is counted\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"1x1 square is counted\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"only complete rectangles are counted\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"rectangles can be of different sizes\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"corner is required for a rectangle to be complete\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"large input with many rectangles\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"nested rectangles\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    },
+    {
+      "name": "\"side by side rectangles\"",
+      "cmd": "bash rectangles.sh <<INPUT"
+    }
+  ]
+}

--- a/exercises/resistor-color-duo/.meta/config.json
+++ b/exercises/resistor-color-duo/.meta/config.json
@@ -1,0 +1,31 @@
+{
+  "solution_files": [
+    "resistor_color_duo.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"brown black\"",
+      "cmd": "bash resistor_color_duo.sh brown black"
+    },
+    {
+      "name": "\"blue grey\"",
+      "cmd": "bash resistor_color_duo.sh blue grey"
+    },
+    {
+      "name": "\"yellow violet\"",
+      "cmd": "bash resistor_color_duo.sh yellow violet"
+    },
+    {
+      "name": "\"orange orange\"",
+      "cmd": "bash resistor_color_duo.sh orange orange"
+    },
+    {
+      "name": "\"invalid color\"",
+      "cmd": "bash resistor_color_duo.sh foo"
+    },
+    {
+      "name": "\"ignore too many colors\"",
+      "cmd": "bash resistor_color_duo.sh green brown orange"
+    }
+  ]
+}

--- a/exercises/resistor-color-duo/.meta/config.json
+++ b/exercises/resistor-color-duo/.meta/config.json
@@ -4,27 +4,27 @@
   ],
   "tests": [
     {
-      "name": "\"brown black\"",
+      "name": "brown black",
       "cmd": "bash resistor_color_duo.sh brown black"
     },
     {
-      "name": "\"blue grey\"",
+      "name": "blue grey",
       "cmd": "bash resistor_color_duo.sh blue grey"
     },
     {
-      "name": "\"yellow violet\"",
+      "name": "yellow violet",
       "cmd": "bash resistor_color_duo.sh yellow violet"
     },
     {
-      "name": "\"orange orange\"",
+      "name": "orange orange",
       "cmd": "bash resistor_color_duo.sh orange orange"
     },
     {
-      "name": "\"invalid color\"",
+      "name": "invalid color",
       "cmd": "bash resistor_color_duo.sh foo"
     },
     {
-      "name": "\"ignore too many colors\"",
+      "name": "ignore too many colors",
       "cmd": "bash resistor_color_duo.sh green brown orange"
     }
   ]

--- a/exercises/resistor-color-trio/.meta/config.json
+++ b/exercises/resistor-color-trio/.meta/config.json
@@ -1,0 +1,63 @@
+{
+  "solution_files": [
+    "resistor_color_trio.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Orange and orange and black\"",
+      "cmd": "bash resistor_color_trio.sh \"orange\" \"orange\" \"black\""
+    },
+    {
+      "name": "\"Blue and grey and brown\"",
+      "cmd": "bash resistor_color_trio.sh \"blue\" \"grey\" \"brown\""
+    },
+    {
+      "name": "\"Brown and red and red\"",
+      "cmd": "bash resistor_color_trio.sh \"brown\" \"red\" \"red\""
+    },
+    {
+      "name": "\"Red and black and red\"",
+      "cmd": "bash resistor_color_trio.sh \"red\" \"black\" \"red\""
+    },
+    {
+      "name": "\"Green and brown and orange\"",
+      "cmd": "bash resistor_color_trio.sh \"green\" \"brown\" \"orange\""
+    },
+    {
+      "name": "\"Yellow and violet and yellow\"",
+      "cmd": "bash resistor_color_trio.sh \"yellow\" \"violet\" \"yellow\""
+    },
+    {
+      "name": "\"Blue and violet and grey\"",
+      "cmd": "bash resistor_color_trio.sh \"blue\" \"violet\" \"grey\""
+    },
+    {
+      "name": "\"Minimum possible value\"",
+      "cmd": "bash resistor_color_trio.sh \"black\" \"black\" \"black\""
+    },
+    {
+      "name": "\"Maximum possible value\"",
+      "cmd": "bash resistor_color_trio.sh \"white\" \"white\" \"white\""
+    },
+    {
+      "name": "\"Invalid first color\"",
+      "cmd": "bash resistor_color_trio.sh \"foo\" \"white\" \"white\""
+    },
+    {
+      "name": "\"Invalid second color\"",
+      "cmd": "bash resistor_color_trio.sh \"white\" \"bar\" \"white\""
+    },
+    {
+      "name": "\"Invalid third color\"",
+      "cmd": "bash resistor_color_trio.sh \"white\" \"white\" \"baz\""
+    },
+    {
+      "name": "\"First two colors make an invalid octal number\"",
+      "cmd": "bash resistor_color_trio.sh \"black\" \"grey\" \"black\""
+    },
+    {
+      "name": "\"Ignore extra colors\"",
+      "cmd": "bash resistor_color_trio.sh \"blue\" \"green\" \"yellow\" \"orange\""
+    }
+  ]
+}

--- a/exercises/resistor-color-trio/.meta/config.json
+++ b/exercises/resistor-color-trio/.meta/config.json
@@ -4,59 +4,59 @@
   ],
   "tests": [
     {
-      "name": "\"Orange and orange and black\"",
+      "name": "Orange and orange and black",
       "cmd": "bash resistor_color_trio.sh \"orange\" \"orange\" \"black\""
     },
     {
-      "name": "\"Blue and grey and brown\"",
+      "name": "Blue and grey and brown",
       "cmd": "bash resistor_color_trio.sh \"blue\" \"grey\" \"brown\""
     },
     {
-      "name": "\"Brown and red and red\"",
+      "name": "Brown and red and red",
       "cmd": "bash resistor_color_trio.sh \"brown\" \"red\" \"red\""
     },
     {
-      "name": "\"Red and black and red\"",
+      "name": "Red and black and red",
       "cmd": "bash resistor_color_trio.sh \"red\" \"black\" \"red\""
     },
     {
-      "name": "\"Green and brown and orange\"",
+      "name": "Green and brown and orange",
       "cmd": "bash resistor_color_trio.sh \"green\" \"brown\" \"orange\""
     },
     {
-      "name": "\"Yellow and violet and yellow\"",
+      "name": "Yellow and violet and yellow",
       "cmd": "bash resistor_color_trio.sh \"yellow\" \"violet\" \"yellow\""
     },
     {
-      "name": "\"Blue and violet and grey\"",
+      "name": "Blue and violet and grey",
       "cmd": "bash resistor_color_trio.sh \"blue\" \"violet\" \"grey\""
     },
     {
-      "name": "\"Minimum possible value\"",
+      "name": "Minimum possible value",
       "cmd": "bash resistor_color_trio.sh \"black\" \"black\" \"black\""
     },
     {
-      "name": "\"Maximum possible value\"",
+      "name": "Maximum possible value",
       "cmd": "bash resistor_color_trio.sh \"white\" \"white\" \"white\""
     },
     {
-      "name": "\"Invalid first color\"",
+      "name": "Invalid first color",
       "cmd": "bash resistor_color_trio.sh \"foo\" \"white\" \"white\""
     },
     {
-      "name": "\"Invalid second color\"",
+      "name": "Invalid second color",
       "cmd": "bash resistor_color_trio.sh \"white\" \"bar\" \"white\""
     },
     {
-      "name": "\"Invalid third color\"",
+      "name": "Invalid third color",
       "cmd": "bash resistor_color_trio.sh \"white\" \"white\" \"baz\""
     },
     {
-      "name": "\"First two colors make an invalid octal number\"",
+      "name": "First two colors make an invalid octal number",
       "cmd": "bash resistor_color_trio.sh \"black\" \"grey\" \"black\""
     },
     {
-      "name": "\"Ignore extra colors\"",
+      "name": "Ignore extra colors",
       "cmd": "bash resistor_color_trio.sh \"blue\" \"green\" \"yellow\" \"orange\""
     }
   ]

--- a/exercises/reverse-string/.meta/config.json
+++ b/exercises/reverse-string/.meta/config.json
@@ -4,31 +4,31 @@
   ],
   "tests": [
     {
-      "name": "\"an empty string\"",
+      "name": "an empty string",
       "cmd": "bash reverse_string.sh \"\""
     },
     {
-      "name": "\"a word\"",
+      "name": "a word",
       "cmd": "bash reverse_string.sh \"robot\""
     },
     {
-      "name": "\"a capitalised word\"",
+      "name": "a capitalised word",
       "cmd": "bash reverse_string.sh \"Ramen\""
     },
     {
-      "name": "\"a sentence with punctuation\"",
+      "name": "a sentence with punctuation",
       "cmd": "bash reverse_string.sh \"I'm hungry!\""
     },
     {
-      "name": "\"a palindrome\"",
+      "name": "a palindrome",
       "cmd": "bash reverse_string.sh \"racecar\""
     },
     {
-      "name": "\"an even-sized word\"",
+      "name": "an even-sized word",
       "cmd": "bash reverse_string.sh \"drawer\""
     },
     {
-      "name": "\"avoid globbing\"",
+      "name": "avoid globbing",
       "cmd": "bash reverse_string.sh \" a * b\""
     }
   ]

--- a/exercises/reverse-string/.meta/config.json
+++ b/exercises/reverse-string/.meta/config.json
@@ -1,0 +1,35 @@
+{
+  "solution_files": [
+    "reverse_string.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"an empty string\"",
+      "cmd": "bash reverse_string.sh \"\""
+    },
+    {
+      "name": "\"a word\"",
+      "cmd": "bash reverse_string.sh \"robot\""
+    },
+    {
+      "name": "\"a capitalised word\"",
+      "cmd": "bash reverse_string.sh \"Ramen\""
+    },
+    {
+      "name": "\"a sentence with punctuation\"",
+      "cmd": "bash reverse_string.sh \"I'm hungry!\""
+    },
+    {
+      "name": "\"a palindrome\"",
+      "cmd": "bash reverse_string.sh \"racecar\""
+    },
+    {
+      "name": "\"an even-sized word\"",
+      "cmd": "bash reverse_string.sh \"drawer\""
+    },
+    {
+      "name": "\"avoid globbing\"",
+      "cmd": "bash reverse_string.sh \" a * b\""
+    }
+  ]
+}

--- a/exercises/rna-transcription/.meta/config.json
+++ b/exercises/rna-transcription/.meta/config.json
@@ -4,39 +4,39 @@
   ],
   "tests": [
     {
-      "name": "\"Empty RNA sequence\"",
+      "name": "Empty RNA sequence",
       "cmd": "bash rna_transcription.sh"
     },
     {
-      "name": "\"RNA complement of cytosine is guanine\"",
+      "name": "RNA complement of cytosine is guanine",
       "cmd": "bash rna_transcription.sh C"
     },
     {
-      "name": "\"RNA complement of guanine is cytosine\"",
+      "name": "RNA complement of guanine is cytosine",
       "cmd": "bash rna_transcription.sh G"
     },
     {
-      "name": "\"RNA complement of thymine is adenine\"",
+      "name": "RNA complement of thymine is adenine",
       "cmd": "bash rna_transcription.sh T"
     },
     {
-      "name": "\"RNA complement of adenine is uracil\"",
+      "name": "RNA complement of adenine is uracil",
       "cmd": "bash rna_transcription.sh A"
     },
     {
-      "name": "\"RNA complement\"",
+      "name": "RNA complement",
       "cmd": "bash rna_transcription.sh ACGTGGTCTTAA"
     },
     {
-      "name": "\"Handles invalid character\"",
+      "name": "Handles invalid character",
       "cmd": "bash rna_transcription.sh ACGTXCTTA"
     },
     {
-      "name": "\"Handles completely invalid string\"",
+      "name": "Handles completely invalid string",
       "cmd": "bash rna_transcription.sh XXXX"
     },
     {
-      "name": "\"Handles partially invalid string\"",
+      "name": "Handles partially invalid string",
       "cmd": "bash rna_transcription.sh ACGTXCTTAA"
     }
   ]

--- a/exercises/rna-transcription/.meta/config.json
+++ b/exercises/rna-transcription/.meta/config.json
@@ -1,0 +1,43 @@
+{
+  "solution_files": [
+    "rna_transcription.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Empty RNA sequence\"",
+      "cmd": "bash rna_transcription.sh"
+    },
+    {
+      "name": "\"RNA complement of cytosine is guanine\"",
+      "cmd": "bash rna_transcription.sh C"
+    },
+    {
+      "name": "\"RNA complement of guanine is cytosine\"",
+      "cmd": "bash rna_transcription.sh G"
+    },
+    {
+      "name": "\"RNA complement of thymine is adenine\"",
+      "cmd": "bash rna_transcription.sh T"
+    },
+    {
+      "name": "\"RNA complement of adenine is uracil\"",
+      "cmd": "bash rna_transcription.sh A"
+    },
+    {
+      "name": "\"RNA complement\"",
+      "cmd": "bash rna_transcription.sh ACGTGGTCTTAA"
+    },
+    {
+      "name": "\"Handles invalid character\"",
+      "cmd": "bash rna_transcription.sh ACGTXCTTA"
+    },
+    {
+      "name": "\"Handles completely invalid string\"",
+      "cmd": "bash rna_transcription.sh XXXX"
+    },
+    {
+      "name": "\"Handles partially invalid string\"",
+      "cmd": "bash rna_transcription.sh ACGTXCTTAA"
+    }
+  ]
+}

--- a/exercises/robot-simulator/.meta/config.json
+++ b/exercises/robot-simulator/.meta/config.json
@@ -1,0 +1,91 @@
+{
+  "solution_files": [
+    "robot_simulator.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Robots are created with a position and direction\"",
+      "cmd": "bash robot_simulator.sh 0 0 north"
+    },
+    {
+      "name": "\"Robots are created with a default position and direction\"",
+      "cmd": "bash robot_simulator.sh"
+    },
+    {
+      "name": "\"Negative positions are allowed\"",
+      "cmd": "bash robot_simulator.sh -1 -1 south"
+    },
+    {
+      "name": "\"changes the direction from north to east\"",
+      "cmd": "bash robot_simulator.sh 0 0 north R"
+    },
+    {
+      "name": "\"changes the direction from east to south\"",
+      "cmd": "bash robot_simulator.sh 0 0 east R"
+    },
+    {
+      "name": "\"changes the direction from south to west\"",
+      "cmd": "bash robot_simulator.sh 0 0 south R"
+    },
+    {
+      "name": "\"changes the direction from west to north\"",
+      "cmd": "bash robot_simulator.sh 0 0 west R"
+    },
+    {
+      "name": "\"changes the direction from north to west\"",
+      "cmd": "bash robot_simulator.sh 0 0 north L"
+    },
+    {
+      "name": "\"changes the direction from west to south\"",
+      "cmd": "bash robot_simulator.sh 0 0 west L"
+    },
+    {
+      "name": "\"changes the direction from south to east\"",
+      "cmd": "bash robot_simulator.sh 0 0 south L"
+    },
+    {
+      "name": "\"changes the direction from east to north\"",
+      "cmd": "bash robot_simulator.sh 0 0 east L"
+    },
+    {
+      "name": "\"increases the y coordinate one when facing north\"",
+      "cmd": "bash robot_simulator.sh 0 0 north A"
+    },
+    {
+      "name": "\"decreases the y coordinate by one when facing south\"",
+      "cmd": "bash robot_simulator.sh 0 0 south A"
+    },
+    {
+      "name": "\"increases the x coordinate by one when facing east\"",
+      "cmd": "bash robot_simulator.sh 0 0 east A"
+    },
+    {
+      "name": "\"decreases the x coordinate by one when facing west\"",
+      "cmd": "bash robot_simulator.sh 0 0 west A"
+    },
+    {
+      "name": "\"instructions to move east and north from README\"",
+      "cmd": "bash robot_simulator.sh 7 3 north RAALAL"
+    },
+    {
+      "name": "\"instructions to move west and north\"",
+      "cmd": "bash robot_simulator.sh 0 0 north LAAARALA"
+    },
+    {
+      "name": "\"instructions to move west and south\"",
+      "cmd": "bash robot_simulator.sh 2 -7 east RRAAAAALA"
+    },
+    {
+      "name": "\"instructions to move east and north\"",
+      "cmd": "bash robot_simulator.sh 8 4 south LAAARRRALLLL"
+    },
+    {
+      "name": "\"invalid direction\"",
+      "cmd": "bash robot_simulator.sh 0 0 foo"
+    },
+    {
+      "name": "\"invalid instructions\"",
+      "cmd": "bash robot_simulator.sh 0 0 north LRAX"
+    }
+  ]
+}

--- a/exercises/robot-simulator/.meta/config.json
+++ b/exercises/robot-simulator/.meta/config.json
@@ -4,87 +4,87 @@
   ],
   "tests": [
     {
-      "name": "\"Robots are created with a position and direction\"",
+      "name": "Robots are created with a position and direction",
       "cmd": "bash robot_simulator.sh 0 0 north"
     },
     {
-      "name": "\"Robots are created with a default position and direction\"",
+      "name": "Robots are created with a default position and direction",
       "cmd": "bash robot_simulator.sh"
     },
     {
-      "name": "\"Negative positions are allowed\"",
+      "name": "Negative positions are allowed",
       "cmd": "bash robot_simulator.sh -1 -1 south"
     },
     {
-      "name": "\"changes the direction from north to east\"",
+      "name": "changes the direction from north to east",
       "cmd": "bash robot_simulator.sh 0 0 north R"
     },
     {
-      "name": "\"changes the direction from east to south\"",
+      "name": "changes the direction from east to south",
       "cmd": "bash robot_simulator.sh 0 0 east R"
     },
     {
-      "name": "\"changes the direction from south to west\"",
+      "name": "changes the direction from south to west",
       "cmd": "bash robot_simulator.sh 0 0 south R"
     },
     {
-      "name": "\"changes the direction from west to north\"",
+      "name": "changes the direction from west to north",
       "cmd": "bash robot_simulator.sh 0 0 west R"
     },
     {
-      "name": "\"changes the direction from north to west\"",
+      "name": "changes the direction from north to west",
       "cmd": "bash robot_simulator.sh 0 0 north L"
     },
     {
-      "name": "\"changes the direction from west to south\"",
+      "name": "changes the direction from west to south",
       "cmd": "bash robot_simulator.sh 0 0 west L"
     },
     {
-      "name": "\"changes the direction from south to east\"",
+      "name": "changes the direction from south to east",
       "cmd": "bash robot_simulator.sh 0 0 south L"
     },
     {
-      "name": "\"changes the direction from east to north\"",
+      "name": "changes the direction from east to north",
       "cmd": "bash robot_simulator.sh 0 0 east L"
     },
     {
-      "name": "\"increases the y coordinate one when facing north\"",
+      "name": "increases the y coordinate one when facing north",
       "cmd": "bash robot_simulator.sh 0 0 north A"
     },
     {
-      "name": "\"decreases the y coordinate by one when facing south\"",
+      "name": "decreases the y coordinate by one when facing south",
       "cmd": "bash robot_simulator.sh 0 0 south A"
     },
     {
-      "name": "\"increases the x coordinate by one when facing east\"",
+      "name": "increases the x coordinate by one when facing east",
       "cmd": "bash robot_simulator.sh 0 0 east A"
     },
     {
-      "name": "\"decreases the x coordinate by one when facing west\"",
+      "name": "decreases the x coordinate by one when facing west",
       "cmd": "bash robot_simulator.sh 0 0 west A"
     },
     {
-      "name": "\"instructions to move east and north from README\"",
+      "name": "instructions to move east and north from README",
       "cmd": "bash robot_simulator.sh 7 3 north RAALAL"
     },
     {
-      "name": "\"instructions to move west and north\"",
+      "name": "instructions to move west and north",
       "cmd": "bash robot_simulator.sh 0 0 north LAAARALA"
     },
     {
-      "name": "\"instructions to move west and south\"",
+      "name": "instructions to move west and south",
       "cmd": "bash robot_simulator.sh 2 -7 east RRAAAAALA"
     },
     {
-      "name": "\"instructions to move east and north\"",
+      "name": "instructions to move east and north",
       "cmd": "bash robot_simulator.sh 8 4 south LAAARRRALLLL"
     },
     {
-      "name": "\"invalid direction\"",
+      "name": "invalid direction",
       "cmd": "bash robot_simulator.sh 0 0 foo"
     },
     {
-      "name": "\"invalid instructions\"",
+      "name": "invalid instructions",
       "cmd": "bash robot_simulator.sh 0 0 north LRAX"
     }
   ]

--- a/exercises/roman-numerals/.meta/config.json
+++ b/exercises/roman-numerals/.meta/config.json
@@ -1,0 +1,83 @@
+{
+  "solution_files": [
+    "roman_numerals.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"1 is a single I\"",
+      "cmd": "bash roman_numerals.sh 1"
+    },
+    {
+      "name": "\"2 is two I's\"",
+      "cmd": "bash roman_numerals.sh 2"
+    },
+    {
+      "name": "\"3 is three I's\"",
+      "cmd": "bash roman_numerals.sh 3"
+    },
+    {
+      "name": "\"4, being 5 - 1, is IV\"",
+      "cmd": "bash roman_numerals.sh 4"
+    },
+    {
+      "name": "\"5 is a single V\"",
+      "cmd": "bash roman_numerals.sh 5"
+    },
+    {
+      "name": "\"6, being 5 + 1, is VI\"",
+      "cmd": "bash roman_numerals.sh 6"
+    },
+    {
+      "name": "\"9, being 10 - 1, is IX\"",
+      "cmd": "bash roman_numerals.sh 9"
+    },
+    {
+      "name": "\"20 is two X's\"",
+      "cmd": "bash roman_numerals.sh 27"
+    },
+    {
+      "name": "\"48 is not 50 - 2 but rather 40 + 8\"",
+      "cmd": "bash roman_numerals.sh 48"
+    },
+    {
+      "name": "\"49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1\"",
+      "cmd": "bash roman_numerals.sh 49"
+    },
+    {
+      "name": "\"50 is a single L\"",
+      "cmd": "bash roman_numerals.sh 59"
+    },
+    {
+      "name": "\"90, being 100 - 10, is XC\"",
+      "cmd": "bash roman_numerals.sh 93"
+    },
+    {
+      "name": "\"100 is a single C\"",
+      "cmd": "bash roman_numerals.sh 141"
+    },
+    {
+      "name": "\"60, being 50 + 10, is LX\"",
+      "cmd": "bash roman_numerals.sh 163"
+    },
+    {
+      "name": "\"400, being 500 - 100, is CD\"",
+      "cmd": "bash roman_numerals.sh 402"
+    },
+    {
+      "name": "\"500 is a single D\"",
+      "cmd": "bash roman_numerals.sh 575"
+    },
+    {
+      "name": "\"900, being 1000 - 100, is CM\"",
+      "cmd": "bash roman_numerals.sh 911"
+    },
+    {
+      "name": "\"1000 is a single M\"",
+      "cmd": "bash roman_numerals.sh 1024"
+    },
+    {
+      "name": "\"3000 is three M's\"",
+      "cmd": "bash roman_numerals.sh 3000"
+    }
+  ]
+}

--- a/exercises/roman-numerals/.meta/config.json
+++ b/exercises/roman-numerals/.meta/config.json
@@ -4,79 +4,79 @@
   ],
   "tests": [
     {
-      "name": "\"1 is a single I\"",
+      "name": "1 is a single I",
       "cmd": "bash roman_numerals.sh 1"
     },
     {
-      "name": "\"2 is two I's\"",
+      "name": "2 is two I's",
       "cmd": "bash roman_numerals.sh 2"
     },
     {
-      "name": "\"3 is three I's\"",
+      "name": "3 is three I's",
       "cmd": "bash roman_numerals.sh 3"
     },
     {
-      "name": "\"4, being 5 - 1, is IV\"",
+      "name": "4, being 5 - 1, is IV",
       "cmd": "bash roman_numerals.sh 4"
     },
     {
-      "name": "\"5 is a single V\"",
+      "name": "5 is a single V",
       "cmd": "bash roman_numerals.sh 5"
     },
     {
-      "name": "\"6, being 5 + 1, is VI\"",
+      "name": "6, being 5 + 1, is VI",
       "cmd": "bash roman_numerals.sh 6"
     },
     {
-      "name": "\"9, being 10 - 1, is IX\"",
+      "name": "9, being 10 - 1, is IX",
       "cmd": "bash roman_numerals.sh 9"
     },
     {
-      "name": "\"20 is two X's\"",
+      "name": "20 is two X's",
       "cmd": "bash roman_numerals.sh 27"
     },
     {
-      "name": "\"48 is not 50 - 2 but rather 40 + 8\"",
+      "name": "48 is not 50 - 2 but rather 40 + 8",
       "cmd": "bash roman_numerals.sh 48"
     },
     {
-      "name": "\"49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1\"",
+      "name": "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1",
       "cmd": "bash roman_numerals.sh 49"
     },
     {
-      "name": "\"50 is a single L\"",
+      "name": "50 is a single L",
       "cmd": "bash roman_numerals.sh 59"
     },
     {
-      "name": "\"90, being 100 - 10, is XC\"",
+      "name": "90, being 100 - 10, is XC",
       "cmd": "bash roman_numerals.sh 93"
     },
     {
-      "name": "\"100 is a single C\"",
+      "name": "100 is a single C",
       "cmd": "bash roman_numerals.sh 141"
     },
     {
-      "name": "\"60, being 50 + 10, is LX\"",
+      "name": "60, being 50 + 10, is LX",
       "cmd": "bash roman_numerals.sh 163"
     },
     {
-      "name": "\"400, being 500 - 100, is CD\"",
+      "name": "400, being 500 - 100, is CD",
       "cmd": "bash roman_numerals.sh 402"
     },
     {
-      "name": "\"500 is a single D\"",
+      "name": "500 is a single D",
       "cmd": "bash roman_numerals.sh 575"
     },
     {
-      "name": "\"900, being 1000 - 100, is CM\"",
+      "name": "900, being 1000 - 100, is CM",
       "cmd": "bash roman_numerals.sh 911"
     },
     {
-      "name": "\"1000 is a single M\"",
+      "name": "1000 is a single M",
       "cmd": "bash roman_numerals.sh 1024"
     },
     {
-      "name": "\"3000 is three M's\"",
+      "name": "3000 is three M's",
       "cmd": "bash roman_numerals.sh 3000"
     }
   ]

--- a/exercises/rotational-cipher/.meta/config.json
+++ b/exercises/rotational-cipher/.meta/config.json
@@ -4,43 +4,43 @@
   ],
   "tests": [
     {
-      "name": "\"rotate a by 0, same output as input\"",
+      "name": "rotate a by 0, same output as input",
       "cmd": "bash rotational_cipher.sh \"a\" 0"
     },
     {
-      "name": "\"rotate a by 1\"",
+      "name": "rotate a by 1",
       "cmd": "bash rotational_cipher.sh \"a\" 1"
     },
     {
-      "name": "\"rotate a by 26, same output as input\"",
+      "name": "rotate a by 26, same output as input",
       "cmd": "bash rotational_cipher.sh \"a\" 26"
     },
     {
-      "name": "\"rotate m by 13\"",
+      "name": "rotate m by 13",
       "cmd": "bash rotational_cipher.sh \"m\" 13"
     },
     {
-      "name": "\"rotate n by 13 with wrap around alphabet\"",
+      "name": "rotate n by 13 with wrap around alphabet",
       "cmd": "bash rotational_cipher.sh \"n\" 13"
     },
     {
-      "name": "\"rotate capital letters\"",
+      "name": "rotate capital letters",
       "cmd": "bash rotational_cipher.sh \"OMG\" 5"
     },
     {
-      "name": "\"rotate spaces\"",
+      "name": "rotate spaces",
       "cmd": "bash rotational_cipher.sh \"O M G\" 5"
     },
     {
-      "name": "\"rotate numbers\"",
+      "name": "rotate numbers",
       "cmd": "bash rotational_cipher.sh \"Testing 1 2 3 testing\" 4"
     },
     {
-      "name": "\"rotate punctuation\"",
+      "name": "rotate punctuation",
       "cmd": "bash rotational_cipher.sh \"Let's eat, Grandma!\" 21"
     },
     {
-      "name": "\"rotate all letters\"",
+      "name": "rotate all letters",
       "cmd": "bash rotational_cipher.sh \"The quick brown fox jumps over the lazy dog.\" 13"
     }
   ]

--- a/exercises/rotational-cipher/.meta/config.json
+++ b/exercises/rotational-cipher/.meta/config.json
@@ -1,0 +1,47 @@
+{
+  "solution_files": [
+    "rotational_cipher.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"rotate a by 0, same output as input\"",
+      "cmd": "bash rotational_cipher.sh \"a\" 0"
+    },
+    {
+      "name": "\"rotate a by 1\"",
+      "cmd": "bash rotational_cipher.sh \"a\" 1"
+    },
+    {
+      "name": "\"rotate a by 26, same output as input\"",
+      "cmd": "bash rotational_cipher.sh \"a\" 26"
+    },
+    {
+      "name": "\"rotate m by 13\"",
+      "cmd": "bash rotational_cipher.sh \"m\" 13"
+    },
+    {
+      "name": "\"rotate n by 13 with wrap around alphabet\"",
+      "cmd": "bash rotational_cipher.sh \"n\" 13"
+    },
+    {
+      "name": "\"rotate capital letters\"",
+      "cmd": "bash rotational_cipher.sh \"OMG\" 5"
+    },
+    {
+      "name": "\"rotate spaces\"",
+      "cmd": "bash rotational_cipher.sh \"O M G\" 5"
+    },
+    {
+      "name": "\"rotate numbers\"",
+      "cmd": "bash rotational_cipher.sh \"Testing 1 2 3 testing\" 4"
+    },
+    {
+      "name": "\"rotate punctuation\"",
+      "cmd": "bash rotational_cipher.sh \"Let's eat, Grandma!\" 21"
+    },
+    {
+      "name": "\"rotate all letters\"",
+      "cmd": "bash rotational_cipher.sh \"The quick brown fox jumps over the lazy dog.\" 13"
+    }
+  ]
+}

--- a/exercises/run-length-encoding/.meta/config.json
+++ b/exercises/run-length-encoding/.meta/config.json
@@ -1,0 +1,59 @@
+{
+  "solution_files": [
+    "run_length_encoding.sh"
+  ],
+  "tests": [
+    {
+      "name": "encode empty string",
+      "cmd": "bash run_length_encoding.sh encode \"\""
+    },
+    {
+      "name": "encode single characters only are encoded without count",
+      "cmd": "bash run_length_encoding.sh encode \"XYZ\""
+    },
+    {
+      "name": "encode string with no single characters",
+      "cmd": "bash run_length_encoding.sh encode \"AABBBCCCC\""
+    },
+    {
+      "name": "encode single characters mixed with repeated characters",
+      "cmd": "bash run_length_encoding.sh encode \"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB\""
+    },
+    {
+      "name": "encode multiple whitespace mixed in string",
+      "cmd": "bash run_length_encoding.sh encode \" hsqq qww \""
+    },
+    {
+      "name": "encode lowercase characters",
+      "cmd": "bash run_length_encoding.sh encode \"aabbbcccc\""
+    },
+    {
+      "name": "decode empty string",
+      "cmd": "bash run_length_encoding.sh decode \"\""
+    },
+    {
+      "name": "single characters only",
+      "cmd": "bash run_length_encoding.sh decode \"XYZ\""
+    },
+    {
+      "name": "decode string with no single characters",
+      "cmd": "bash run_length_encoding.sh decode \"2A3B4C\""
+    },
+    {
+      "name": "decode single characters with repeated characters",
+      "cmd": "bash run_length_encoding.sh decode \"12WB12W3B24WB\""
+    },
+    {
+      "name": "decode multiple whitespace mixed in string",
+      "cmd": "bash run_length_encoding.sh decode \"2 hs2q q2w2 \""
+    },
+    {
+      "name": "decode lower case string",
+      "cmd": "bash run_length_encoding.sh decode \"2a3b4c\""
+    },
+    {
+      "name": "encode followed by decode gives original string",
+      "cmd": "bash run_length_encoding.sh encode \"zzz ZZ zZ\""
+    }
+  ]
+}

--- a/exercises/say/.meta/config.json
+++ b/exercises/say/.meta/config.json
@@ -20,47 +20,47 @@
       "cmd": "bash say.sh 20"
     },
     {
-      "name": "\"twenty-two\"",
+      "name": "twenty-two",
       "cmd": "bash say.sh 22"
     },
     {
-      "name": "\"one hundred\"",
+      "name": "one hundred",
       "cmd": "bash say.sh 100"
     },
     {
-      "name": "\"one hundred twenty-three\"",
+      "name": "one hundred twenty-three",
       "cmd": "bash say.sh 123"
     },
     {
-      "name": "\"one thousand\"",
+      "name": "one thousand",
       "cmd": "bash say.sh 1000"
     },
     {
-      "name": "\"one thousand two hundred thirty-four\"",
+      "name": "one thousand two hundred thirty-four",
       "cmd": "bash say.sh 1234"
     },
     {
-      "name": "\"one million\"",
+      "name": "one million",
       "cmd": "bash say.sh 1000000"
     },
     {
-      "name": "\"one million two thousand three hundred forty-five\"",
+      "name": "one million two thousand three hundred forty-five",
       "cmd": "bash say.sh 1002345"
     },
     {
-      "name": "\"one billion\"",
+      "name": "one billion",
       "cmd": "bash say.sh 1000000000"
     },
     {
-      "name": "\"a big number\"",
+      "name": "a big number",
       "cmd": "bash say.sh 987654321123"
     },
     {
-      "name": "\"numbers below zero are out of range\"",
+      "name": "numbers below zero are out of range",
       "cmd": "bash say.sh -1"
     },
     {
-      "name": "\"numbers above 999,999,999,999 are out of range\"",
+      "name": "numbers above 999,999,999,999 are out of range",
       "cmd": "bash say.sh 1000000000000"
     }
   ]

--- a/exercises/say/.meta/config.json
+++ b/exercises/say/.meta/config.json
@@ -1,0 +1,67 @@
+{
+  "solution_files": [
+    "say.sh"
+  ],
+  "tests": [
+    {
+      "name": "zero",
+      "cmd": "bash say.sh 0"
+    },
+    {
+      "name": "one",
+      "cmd": "bash say.sh 1"
+    },
+    {
+      "name": "fourteen",
+      "cmd": "bash say.sh 14"
+    },
+    {
+      "name": "twenty",
+      "cmd": "bash say.sh 20"
+    },
+    {
+      "name": "\"twenty-two\"",
+      "cmd": "bash say.sh 22"
+    },
+    {
+      "name": "\"one hundred\"",
+      "cmd": "bash say.sh 100"
+    },
+    {
+      "name": "\"one hundred twenty-three\"",
+      "cmd": "bash say.sh 123"
+    },
+    {
+      "name": "\"one thousand\"",
+      "cmd": "bash say.sh 1000"
+    },
+    {
+      "name": "\"one thousand two hundred thirty-four\"",
+      "cmd": "bash say.sh 1234"
+    },
+    {
+      "name": "\"one million\"",
+      "cmd": "bash say.sh 1000000"
+    },
+    {
+      "name": "\"one million two thousand three hundred forty-five\"",
+      "cmd": "bash say.sh 1002345"
+    },
+    {
+      "name": "\"one billion\"",
+      "cmd": "bash say.sh 1000000000"
+    },
+    {
+      "name": "\"a big number\"",
+      "cmd": "bash say.sh 987654321123"
+    },
+    {
+      "name": "\"numbers below zero are out of range\"",
+      "cmd": "bash say.sh -1"
+    },
+    {
+      "name": "\"numbers above 999,999,999,999 are out of range\"",
+      "cmd": "bash say.sh 1000000000000"
+    }
+  ]
+}

--- a/exercises/scrabble-score/.meta/config.json
+++ b/exercises/scrabble-score/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "scrabble_score.sh"
+  ],
+  "tests": [
+    {
+      "name": "lowercase letter",
+      "cmd": "bash scrabble_score.sh 'a'"
+    },
+    {
+      "name": "uppercase letter",
+      "cmd": "bash scrabble_score.sh 'A'"
+    },
+    {
+      "name": "valuable letter",
+      "cmd": "bash scrabble_score.sh 'f'"
+    },
+    {
+      "name": "short word",
+      "cmd": "bash scrabble_score.sh 'at'"
+    },
+    {
+      "name": "short, valuable word",
+      "cmd": "bash scrabble_score.sh 'zoo'"
+    },
+    {
+      "name": "medium word",
+      "cmd": "bash scrabble_score.sh 'street'"
+    },
+    {
+      "name": "medium, valuable word",
+      "cmd": "bash scrabble_score.sh 'quirky'"
+    },
+    {
+      "name": "long, mixed-case word",
+      "cmd": "bash scrabble_score.sh 'OxyphenButazone'"
+    },
+    {
+      "name": "english-like word",
+      "cmd": "bash scrabble_score.sh 'pinata'"
+    },
+    {
+      "name": "empty input",
+      "cmd": "bash scrabble_score.sh ''"
+    },
+    {
+      "name": "entire alphabet available",
+      "cmd": "bash scrabble_score.sh 'abcdefghijklmnopqrstuvwxyz'"
+    }
+  ]
+}

--- a/exercises/secret-handshake/.meta/config.json
+++ b/exercises/secret-handshake/.meta/config.json
@@ -4,47 +4,47 @@
   ],
   "tests": [
     {
-      "name": "\"wink for 1\"",
+      "name": "wink for 1",
       "cmd": "bash secret_handshake.sh 1"
     },
     {
-      "name": "\"double blink for 10\"",
+      "name": "double blink for 10",
       "cmd": "bash secret_handshake.sh 2"
     },
     {
-      "name": "\"close your eyes for 100\"",
+      "name": "close your eyes for 100",
       "cmd": "bash secret_handshake.sh 4"
     },
     {
-      "name": "\"jump for 1000\"",
+      "name": "jump for 1000",
       "cmd": "bash secret_handshake.sh 8"
     },
     {
-      "name": "\"combine two actions\"",
+      "name": "combine two actions",
       "cmd": "bash secret_handshake.sh 3"
     },
     {
-      "name": "\"all possible actions\"",
+      "name": "all possible actions",
       "cmd": "bash secret_handshake.sh 15"
     },
     {
-      "name": "\"do nothing for zero\"",
+      "name": "do nothing for zero",
       "cmd": "bash secret_handshake.sh 0"
     },
     {
-      "name": "\"reversing no actions still gives no actions\"",
+      "name": "reversing no actions still gives no actions",
       "cmd": "bash secret_handshake.sh 16"
     },
     {
-      "name": "\"reversing one action gives the same action\"",
+      "name": "reversing one action gives the same action",
       "cmd": "bash secret_handshake.sh 24"
     },
     {
-      "name": "\"reverse two actions\"",
+      "name": "reverse two actions",
       "cmd": "bash secret_handshake.sh 19"
     },
     {
-      "name": "\"reverse all possible actions\"",
+      "name": "reverse all possible actions",
       "cmd": "bash secret_handshake.sh 31"
     }
   ]

--- a/exercises/secret-handshake/.meta/config.json
+++ b/exercises/secret-handshake/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "secret_handshake.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"wink for 1\"",
+      "cmd": "bash secret_handshake.sh 1"
+    },
+    {
+      "name": "\"double blink for 10\"",
+      "cmd": "bash secret_handshake.sh 2"
+    },
+    {
+      "name": "\"close your eyes for 100\"",
+      "cmd": "bash secret_handshake.sh 4"
+    },
+    {
+      "name": "\"jump for 1000\"",
+      "cmd": "bash secret_handshake.sh 8"
+    },
+    {
+      "name": "\"combine two actions\"",
+      "cmd": "bash secret_handshake.sh 3"
+    },
+    {
+      "name": "\"all possible actions\"",
+      "cmd": "bash secret_handshake.sh 15"
+    },
+    {
+      "name": "\"do nothing for zero\"",
+      "cmd": "bash secret_handshake.sh 0"
+    },
+    {
+      "name": "\"reversing no actions still gives no actions\"",
+      "cmd": "bash secret_handshake.sh 16"
+    },
+    {
+      "name": "\"reversing one action gives the same action\"",
+      "cmd": "bash secret_handshake.sh 24"
+    },
+    {
+      "name": "\"reverse two actions\"",
+      "cmd": "bash secret_handshake.sh 19"
+    },
+    {
+      "name": "\"reverse all possible actions\"",
+      "cmd": "bash secret_handshake.sh 31"
+    }
+  ]
+}

--- a/exercises/series/.meta/config.json
+++ b/exercises/series/.meta/config.json
@@ -4,43 +4,43 @@
   ],
   "tests": [
     {
-      "name": "\"slices of one from one\"",
+      "name": "slices of one from one",
       "cmd": "bash series.sh 1 1"
     },
     {
-      "name": "\"slices of one from two\"",
+      "name": "slices of one from two",
       "cmd": "bash series.sh 12 1"
     },
     {
-      "name": "\"slices of two\"",
+      "name": "slices of two",
       "cmd": "bash series.sh 35 2"
     },
     {
-      "name": "\"slices of two overlap\"",
+      "name": "slices of two overlap",
       "cmd": "bash series.sh 9142 2"
     },
     {
-      "name": "\"slices can include duplicates\"",
+      "name": "slices can include duplicates",
       "cmd": "bash series.sh 777777 3"
     },
     {
-      "name": "\"slices of a long series\"",
+      "name": "slices of a long series",
       "cmd": "bash series.sh 918493904243 5"
     },
     {
-      "name": "\"slice length is too large\"",
+      "name": "slice length is too large",
       "cmd": "bash series.sh 12345 6"
     },
     {
-      "name": "\"slice length cannot be zero\"",
+      "name": "slice length cannot be zero",
       "cmd": "bash series.sh 12345 0"
     },
     {
-      "name": "\"slice length cannot be negative\"",
+      "name": "slice length cannot be negative",
       "cmd": "bash series.sh 123 -1"
     },
     {
-      "name": "\"empty series is invalid\"",
+      "name": "empty series is invalid",
       "cmd": "bash series.sh \"\" 1"
     }
   ]

--- a/exercises/series/.meta/config.json
+++ b/exercises/series/.meta/config.json
@@ -1,0 +1,47 @@
+{
+  "solution_files": [
+    "series.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"slices of one from one\"",
+      "cmd": "bash series.sh 1 1"
+    },
+    {
+      "name": "\"slices of one from two\"",
+      "cmd": "bash series.sh 12 1"
+    },
+    {
+      "name": "\"slices of two\"",
+      "cmd": "bash series.sh 35 2"
+    },
+    {
+      "name": "\"slices of two overlap\"",
+      "cmd": "bash series.sh 9142 2"
+    },
+    {
+      "name": "\"slices can include duplicates\"",
+      "cmd": "bash series.sh 777777 3"
+    },
+    {
+      "name": "\"slices of a long series\"",
+      "cmd": "bash series.sh 918493904243 5"
+    },
+    {
+      "name": "\"slice length is too large\"",
+      "cmd": "bash series.sh 12345 6"
+    },
+    {
+      "name": "\"slice length cannot be zero\"",
+      "cmd": "bash series.sh 12345 0"
+    },
+    {
+      "name": "\"slice length cannot be negative\"",
+      "cmd": "bash series.sh 123 -1"
+    },
+    {
+      "name": "\"empty series is invalid\"",
+      "cmd": "bash series.sh \"\" 1"
+    }
+  ]
+}

--- a/exercises/sieve/.meta/config.json
+++ b/exercises/sieve/.meta/config.json
@@ -4,23 +4,23 @@
   ],
   "tests": [
     {
-      "name": "\"no primes under two\"",
+      "name": "no primes under two",
       "cmd": "bash sieve.sh 1"
     },
     {
-      "name": "\"find first prime\"",
+      "name": "find first prime",
       "cmd": "bash sieve.sh 2"
     },
     {
-      "name": "\"find primes up to 10\"",
+      "name": "find primes up to 10",
       "cmd": "bash sieve.sh 10"
     },
     {
-      "name": "\"limit is prime\"",
+      "name": "limit is prime",
       "cmd": "bash sieve.sh 13"
     },
     {
-      "name": "\"find primes up to 1000\"",
+      "name": "find primes up to 1000",
       "cmd": "bash sieve.sh 1000"
     }
   ]

--- a/exercises/sieve/.meta/config.json
+++ b/exercises/sieve/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "sieve.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"no primes under two\"",
+      "cmd": "bash sieve.sh 1"
+    },
+    {
+      "name": "\"find first prime\"",
+      "cmd": "bash sieve.sh 2"
+    },
+    {
+      "name": "\"find primes up to 10\"",
+      "cmd": "bash sieve.sh 10"
+    },
+    {
+      "name": "\"limit is prime\"",
+      "cmd": "bash sieve.sh 13"
+    },
+    {
+      "name": "\"find primes up to 1000\"",
+      "cmd": "bash sieve.sh 1000"
+    }
+  ]
+}

--- a/exercises/simple-cipher/.meta/config.json
+++ b/exercises/simple-cipher/.meta/config.json
@@ -1,0 +1,71 @@
+{
+  "solution_files": [
+    "simple_cipher.sh"
+  ],
+  "tests": [
+    {
+      "name": "Can generate a random key",
+      "cmd": "bash simple_cipher.sh key"
+    },
+    {
+      "name": "Can encode random",
+      "cmd": "bash simple_cipher.sh key"
+    },
+    {
+      "name": "Can decode random",
+      "cmd": "bash simple_cipher.sh key"
+    },
+    {
+      "name": "Is reversible random",
+      "cmd": "bash simple_cipher.sh key"
+    },
+    {
+      "name": "Can encode",
+      "cmd": "bash simple_cipher.sh -k \"$key\" encode \"$txt\""
+    },
+    {
+      "name": "Can decode",
+      "cmd": "bash simple_cipher.sh -k \"$key\" decode \"$txt\""
+    },
+    {
+      "name": "Is reversible",
+      "cmd": "bash simple_cipher.sh -k \"$key\" encode \"$txt\""
+    },
+    {
+      "name": "Can double shift encode",
+      "cmd": "bash simple_cipher.sh -k \"$key\" encode \"$txt\""
+    },
+    {
+      "name": "Can wrap on encode",
+      "cmd": "bash simple_cipher.sh -k \"$key\" encode \"$txt\""
+    },
+    {
+      "name": "Can wrap on decode",
+      "cmd": "bash simple_cipher.sh -k \"$key\" decode \"$txt\""
+    },
+    {
+      "name": "Can encode messages longer than the key",
+      "cmd": "bash simple_cipher.sh -k \"$key\" encode \"$txt\""
+    },
+    {
+      "name": "Can decode messages longer than the key",
+      "cmd": "bash simple_cipher.sh -k \"$key\" decode \"$txt\""
+    },
+    {
+      "name": "plaintext is lowercased",
+      "cmd": "bash simple_cipher.sh -k b encode FOOBAR"
+    },
+    {
+      "name": "ciphertext is lowercased",
+      "cmd": "bash simple_cipher.sh -k b decode GPPCBS"
+    },
+    {
+      "name": "key must be lowercase",
+      "cmd": "bash simple_cipher.sh -k ABC encode foo"
+    },
+    {
+      "name": "key must be letters",
+      "cmd": "bash simple_cipher.sh -k 123 encode foo"
+    }
+  ]
+}

--- a/exercises/space-age/.meta/config.json
+++ b/exercises/space-age/.meta/config.json
@@ -1,0 +1,43 @@
+{
+  "solution_files": [
+    "space_age.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"age on Earth\"",
+      "cmd": "bash space_age.sh \"Earth\" 1000000000"
+    },
+    {
+      "name": "\"age on Mercury\"",
+      "cmd": "bash space_age.sh \"Mercury\" 2134835688"
+    },
+    {
+      "name": "\"age on Venus\"",
+      "cmd": "bash space_age.sh \"Venus\" 189839836"
+    },
+    {
+      "name": "\"age on Mars\"",
+      "cmd": "bash space_age.sh \"Mars\" 2129871239"
+    },
+    {
+      "name": "\"age on Jupiter\"",
+      "cmd": "bash space_age.sh \"Jupiter\" 901876382"
+    },
+    {
+      "name": "\"age on Saturn\"",
+      "cmd": "bash space_age.sh \"Saturn\" 2000000000"
+    },
+    {
+      "name": "\"age on Uranus\"",
+      "cmd": "bash space_age.sh \"Uranus\" 1210123456"
+    },
+    {
+      "name": "\"age on Neptune\"",
+      "cmd": "bash space_age.sh \"Neptune\" 1821023456"
+    },
+    {
+      "name": "\"not a planet\"",
+      "cmd": "bash space_age.sh \"Pluto\" 1821023456"
+    }
+  ]
+}

--- a/exercises/space-age/.meta/config.json
+++ b/exercises/space-age/.meta/config.json
@@ -4,39 +4,39 @@
   ],
   "tests": [
     {
-      "name": "\"age on Earth\"",
+      "name": "age on Earth",
       "cmd": "bash space_age.sh \"Earth\" 1000000000"
     },
     {
-      "name": "\"age on Mercury\"",
+      "name": "age on Mercury",
       "cmd": "bash space_age.sh \"Mercury\" 2134835688"
     },
     {
-      "name": "\"age on Venus\"",
+      "name": "age on Venus",
       "cmd": "bash space_age.sh \"Venus\" 189839836"
     },
     {
-      "name": "\"age on Mars\"",
+      "name": "age on Mars",
       "cmd": "bash space_age.sh \"Mars\" 2129871239"
     },
     {
-      "name": "\"age on Jupiter\"",
+      "name": "age on Jupiter",
       "cmd": "bash space_age.sh \"Jupiter\" 901876382"
     },
     {
-      "name": "\"age on Saturn\"",
+      "name": "age on Saturn",
       "cmd": "bash space_age.sh \"Saturn\" 2000000000"
     },
     {
-      "name": "\"age on Uranus\"",
+      "name": "age on Uranus",
       "cmd": "bash space_age.sh \"Uranus\" 1210123456"
     },
     {
-      "name": "\"age on Neptune\"",
+      "name": "age on Neptune",
       "cmd": "bash space_age.sh \"Neptune\" 1821023456"
     },
     {
-      "name": "\"not a planet\"",
+      "name": "not a planet",
       "cmd": "bash space_age.sh \"Pluto\" 1821023456"
     }
   ]

--- a/exercises/spiral-matrix/.meta/config.json
+++ b/exercises/spiral-matrix/.meta/config.json
@@ -1,0 +1,31 @@
+{
+  "solution_files": [
+    "spiral_matrix.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"empty spiral\"",
+      "cmd": "bash spiral_matrix.sh 0"
+    },
+    {
+      "name": "\"trivial spiral\"",
+      "cmd": "bash spiral_matrix.sh 1"
+    },
+    {
+      "name": "\"spiral of size 2\"",
+      "cmd": "bash spiral_matrix.sh 2"
+    },
+    {
+      "name": "\"spiral of size 3\"",
+      "cmd": "bash spiral_matrix.sh 3"
+    },
+    {
+      "name": "\"spiral of size 4\"",
+      "cmd": "bash spiral_matrix.sh 4"
+    },
+    {
+      "name": "\"spiral of size 5\"",
+      "cmd": "bash spiral_matrix.sh 5"
+    }
+  ]
+}

--- a/exercises/spiral-matrix/.meta/config.json
+++ b/exercises/spiral-matrix/.meta/config.json
@@ -4,27 +4,27 @@
   ],
   "tests": [
     {
-      "name": "\"empty spiral\"",
+      "name": "empty spiral",
       "cmd": "bash spiral_matrix.sh 0"
     },
     {
-      "name": "\"trivial spiral\"",
+      "name": "trivial spiral",
       "cmd": "bash spiral_matrix.sh 1"
     },
     {
-      "name": "\"spiral of size 2\"",
+      "name": "spiral of size 2",
       "cmd": "bash spiral_matrix.sh 2"
     },
     {
-      "name": "\"spiral of size 3\"",
+      "name": "spiral of size 3",
       "cmd": "bash spiral_matrix.sh 3"
     },
     {
-      "name": "\"spiral of size 4\"",
+      "name": "spiral of size 4",
       "cmd": "bash spiral_matrix.sh 4"
     },
     {
-      "name": "\"spiral of size 5\"",
+      "name": "spiral of size 5",
       "cmd": "bash spiral_matrix.sh 5"
     }
   ]

--- a/exercises/sublist/.meta/config.json
+++ b/exercises/sublist/.meta/config.json
@@ -4,71 +4,71 @@
   ],
   "tests": [
     {
-      "name": "\"empty lists\"",
+      "name": "empty lists",
       "cmd": "bash sublist.sh \"[]\" \"[]\""
     },
     {
-      "name": "\"empty list within non empty list\"",
+      "name": "empty list within non empty list",
       "cmd": "bash sublist.sh \"[]\" \"[1, 2, 3]\""
     },
     {
-      "name": "\"non empty list contains empty list\"",
+      "name": "non empty list contains empty list",
       "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[]\""
     },
     {
-      "name": "\"list equals itself\"",
+      "name": "list equals itself",
       "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[1, 2, 3]\""
     },
     {
-      "name": "\"different lists\"",
+      "name": "different lists",
       "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[2, 3, 4]\""
     },
     {
-      "name": "\"false start\"",
+      "name": "false start",
       "cmd": "bash sublist.sh \"[1, 2, 5]\" \"[0, 1, 2, 3, 1, 2, 5, 6]\""
     },
     {
-      "name": "\"consecutive\"",
+      "name": "consecutive",
       "cmd": "bash sublist.sh \"[1, 1, 2]\" \"[0, 1, 1, 1, 2, 1, 2]\""
     },
     {
-      "name": "\"sublist at start\"",
+      "name": "sublist at start",
       "cmd": "bash sublist.sh \"[0, 1, 2]\" \"[0, 1, 2, 3, 4, 5]\""
     },
     {
-      "name": "\"sublist in middle\"",
+      "name": "sublist in middle",
       "cmd": "bash sublist.sh \"[2, 3, 4]\" \"[0, 1, 2, 3, 4, 5]\""
     },
     {
-      "name": "\"sublist at end\"",
+      "name": "sublist at end",
       "cmd": "bash sublist.sh \"[3, 4, 5]\" \"[0, 1, 2, 3, 4, 5]\""
     },
     {
-      "name": "\"at start of superlist\"",
+      "name": "at start of superlist",
       "cmd": "bash sublist.sh \"[0, 1, 2, 3, 4, 5]\" \"[0, 1, 2]\""
     },
     {
-      "name": "\"in middle of superlist\"",
+      "name": "in middle of superlist",
       "cmd": "bash sublist.sh \"[0, 1, 2, 3, 4, 5]\" \"[2, 3]\""
     },
     {
-      "name": "\"at end of superlist\"",
+      "name": "at end of superlist",
       "cmd": "bash sublist.sh \"[0, 1, 2, 3, 4, 5]\" \"[3, 4, 5]\""
     },
     {
-      "name": "\"first list missing element from second list\"",
+      "name": "first list missing element from second list",
       "cmd": "bash sublist.sh \"[1, 3]\" \"[1, 2, 3]\""
     },
     {
-      "name": "\"second list missing element from first list\"",
+      "name": "second list missing element from first list",
       "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[1, 3]\""
     },
     {
-      "name": "\"order matters to a list\"",
+      "name": "order matters to a list",
       "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[3, 2, 1]\""
     },
     {
-      "name": "\"same digits but different numbers\"",
+      "name": "same digits but different numbers",
       "cmd": "bash sublist.sh \"[1, 0, 1]\" \"[10, 1]\""
     }
   ]

--- a/exercises/sublist/.meta/config.json
+++ b/exercises/sublist/.meta/config.json
@@ -1,0 +1,75 @@
+{
+  "solution_files": [
+    "sublist.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"empty lists\"",
+      "cmd": "bash sublist.sh \"[]\" \"[]\""
+    },
+    {
+      "name": "\"empty list within non empty list\"",
+      "cmd": "bash sublist.sh \"[]\" \"[1, 2, 3]\""
+    },
+    {
+      "name": "\"non empty list contains empty list\"",
+      "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[]\""
+    },
+    {
+      "name": "\"list equals itself\"",
+      "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[1, 2, 3]\""
+    },
+    {
+      "name": "\"different lists\"",
+      "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[2, 3, 4]\""
+    },
+    {
+      "name": "\"false start\"",
+      "cmd": "bash sublist.sh \"[1, 2, 5]\" \"[0, 1, 2, 3, 1, 2, 5, 6]\""
+    },
+    {
+      "name": "\"consecutive\"",
+      "cmd": "bash sublist.sh \"[1, 1, 2]\" \"[0, 1, 1, 1, 2, 1, 2]\""
+    },
+    {
+      "name": "\"sublist at start\"",
+      "cmd": "bash sublist.sh \"[0, 1, 2]\" \"[0, 1, 2, 3, 4, 5]\""
+    },
+    {
+      "name": "\"sublist in middle\"",
+      "cmd": "bash sublist.sh \"[2, 3, 4]\" \"[0, 1, 2, 3, 4, 5]\""
+    },
+    {
+      "name": "\"sublist at end\"",
+      "cmd": "bash sublist.sh \"[3, 4, 5]\" \"[0, 1, 2, 3, 4, 5]\""
+    },
+    {
+      "name": "\"at start of superlist\"",
+      "cmd": "bash sublist.sh \"[0, 1, 2, 3, 4, 5]\" \"[0, 1, 2]\""
+    },
+    {
+      "name": "\"in middle of superlist\"",
+      "cmd": "bash sublist.sh \"[0, 1, 2, 3, 4, 5]\" \"[2, 3]\""
+    },
+    {
+      "name": "\"at end of superlist\"",
+      "cmd": "bash sublist.sh \"[0, 1, 2, 3, 4, 5]\" \"[3, 4, 5]\""
+    },
+    {
+      "name": "\"first list missing element from second list\"",
+      "cmd": "bash sublist.sh \"[1, 3]\" \"[1, 2, 3]\""
+    },
+    {
+      "name": "\"second list missing element from first list\"",
+      "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[1, 3]\""
+    },
+    {
+      "name": "\"order matters to a list\"",
+      "cmd": "bash sublist.sh \"[1, 2, 3]\" \"[3, 2, 1]\""
+    },
+    {
+      "name": "\"same digits but different numbers\"",
+      "cmd": "bash sublist.sh \"[1, 0, 1]\" \"[10, 1]\""
+    }
+  ]
+}

--- a/exercises/sum-of-multiples/.meta/config.json
+++ b/exercises/sum-of-multiples/.meta/config.json
@@ -1,0 +1,71 @@
+{
+  "solution_files": [
+    "sum_of_multiples.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"no multiples within limit\"",
+      "cmd": "bash sum_of_multiples.sh 1 3 5"
+    },
+    {
+      "name": "\"one factor has multiples within limit\"",
+      "cmd": "bash sum_of_multiples.sh 4 3 5"
+    },
+    {
+      "name": "\"more than one multiple within limit\"",
+      "cmd": "bash sum_of_multiples.sh 7 3"
+    },
+    {
+      "name": "\"more than one factor with multiples within limit\"",
+      "cmd": "bash sum_of_multiples.sh 10 3 5"
+    },
+    {
+      "name": "\"each multiple is only counted once\"",
+      "cmd": "bash sum_of_multiples.sh 100 3 5"
+    },
+    {
+      "name": "\"a much larger limit\"",
+      "cmd": "bash sum_of_multiples.sh 1000 3 5"
+    },
+    {
+      "name": "\"three factors\"",
+      "cmd": "bash sum_of_multiples.sh 20 7 13 17"
+    },
+    {
+      "name": "\"factors not relatively prime\"",
+      "cmd": "bash sum_of_multiples.sh 15 4 6"
+    },
+    {
+      "name": "\"some pairs of factors relatively prime and some not\"",
+      "cmd": "bash sum_of_multiples.sh 150 5 6 8"
+    },
+    {
+      "name": "\"one factor is a multiple of another\"",
+      "cmd": "bash sum_of_multiples.sh 51 5 25"
+    },
+    {
+      "name": "\"much larger factors\"",
+      "cmd": "bash sum_of_multiples.sh 10000 43 47"
+    },
+    {
+      "name": "\"all numbers are multiples of 1\"",
+      "cmd": "bash sum_of_multiples.sh 100 1"
+    },
+    {
+      "name": "\"no factors means an empty sum\"",
+      "cmd": "bash sum_of_multiples.sh 10000"
+    },
+    {
+      "name": "\"the only multiple of 0 is 0\"",
+      "cmd": "bash sum_of_multiples.sh 1 0"
+    },
+    {
+      "name": "\"the factor 0 does not affect the sum of multiples of other factors\"",
+      "cmd": "bash sum_of_multiples.sh 4 3 0"
+    },
+    {
+      "name": "\"solutions using include-exclude must extend to cardinality greater than 3\"",
+      "cmd": "bash sum_of_multiples.sh 10000 2 3 5 7 11"
+    }
+  ]
+}

--- a/exercises/sum-of-multiples/.meta/config.json
+++ b/exercises/sum-of-multiples/.meta/config.json
@@ -4,67 +4,67 @@
   ],
   "tests": [
     {
-      "name": "\"no multiples within limit\"",
+      "name": "no multiples within limit",
       "cmd": "bash sum_of_multiples.sh 1 3 5"
     },
     {
-      "name": "\"one factor has multiples within limit\"",
+      "name": "one factor has multiples within limit",
       "cmd": "bash sum_of_multiples.sh 4 3 5"
     },
     {
-      "name": "\"more than one multiple within limit\"",
+      "name": "more than one multiple within limit",
       "cmd": "bash sum_of_multiples.sh 7 3"
     },
     {
-      "name": "\"more than one factor with multiples within limit\"",
+      "name": "more than one factor with multiples within limit",
       "cmd": "bash sum_of_multiples.sh 10 3 5"
     },
     {
-      "name": "\"each multiple is only counted once\"",
+      "name": "each multiple is only counted once",
       "cmd": "bash sum_of_multiples.sh 100 3 5"
     },
     {
-      "name": "\"a much larger limit\"",
+      "name": "a much larger limit",
       "cmd": "bash sum_of_multiples.sh 1000 3 5"
     },
     {
-      "name": "\"three factors\"",
+      "name": "three factors",
       "cmd": "bash sum_of_multiples.sh 20 7 13 17"
     },
     {
-      "name": "\"factors not relatively prime\"",
+      "name": "factors not relatively prime",
       "cmd": "bash sum_of_multiples.sh 15 4 6"
     },
     {
-      "name": "\"some pairs of factors relatively prime and some not\"",
+      "name": "some pairs of factors relatively prime and some not",
       "cmd": "bash sum_of_multiples.sh 150 5 6 8"
     },
     {
-      "name": "\"one factor is a multiple of another\"",
+      "name": "one factor is a multiple of another",
       "cmd": "bash sum_of_multiples.sh 51 5 25"
     },
     {
-      "name": "\"much larger factors\"",
+      "name": "much larger factors",
       "cmd": "bash sum_of_multiples.sh 10000 43 47"
     },
     {
-      "name": "\"all numbers are multiples of 1\"",
+      "name": "all numbers are multiples of 1",
       "cmd": "bash sum_of_multiples.sh 100 1"
     },
     {
-      "name": "\"no factors means an empty sum\"",
+      "name": "no factors means an empty sum",
       "cmd": "bash sum_of_multiples.sh 10000"
     },
     {
-      "name": "\"the only multiple of 0 is 0\"",
+      "name": "the only multiple of 0 is 0",
       "cmd": "bash sum_of_multiples.sh 1 0"
     },
     {
-      "name": "\"the factor 0 does not affect the sum of multiples of other factors\"",
+      "name": "the factor 0 does not affect the sum of multiples of other factors",
       "cmd": "bash sum_of_multiples.sh 4 3 0"
     },
     {
-      "name": "\"solutions using include-exclude must extend to cardinality greater than 3\"",
+      "name": "solutions using include-exclude must extend to cardinality greater than 3",
       "cmd": "bash sum_of_multiples.sh 10000 2 3 5 7 11"
     }
   ]

--- a/exercises/tournament/.meta/config.json
+++ b/exercises/tournament/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "tournament.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"just the header if no input\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"a win is three points, a loss is zero points\"",
+      "cmd": "bash tournament.sh \"$INPUT_FILE\""
+    },
+    {
+      "name": "\"a win can also be expressed as a loss\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"a different team can win\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"a draw is one point each\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"There can be more than one match\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"There can be more than one winner\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"There can be more than two teams\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"typical input\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    },
+    {
+      "name": "\"incomplete competition (not all pairs have played)\"",
+      "cmd": "bash tournament.sh \"$INPUT_FILE\""
+    },
+    {
+      "name": "\"ties broken alphabetically\"",
+      "cmd": "bash tournament.sh <<< \"$input\""
+    }
+  ]
+}

--- a/exercises/tournament/.meta/config.json
+++ b/exercises/tournament/.meta/config.json
@@ -4,47 +4,47 @@
   ],
   "tests": [
     {
-      "name": "\"just the header if no input\"",
+      "name": "just the header if no input",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"a win is three points, a loss is zero points\"",
+      "name": "a win is three points, a loss is zero points",
       "cmd": "bash tournament.sh \"$INPUT_FILE\""
     },
     {
-      "name": "\"a win can also be expressed as a loss\"",
+      "name": "a win can also be expressed as a loss",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"a different team can win\"",
+      "name": "a different team can win",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"a draw is one point each\"",
+      "name": "a draw is one point each",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"There can be more than one match\"",
+      "name": "There can be more than one match",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"There can be more than one winner\"",
+      "name": "There can be more than one winner",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"There can be more than two teams\"",
+      "name": "There can be more than two teams",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"typical input\"",
+      "name": "typical input",
       "cmd": "bash tournament.sh <<< \"$input\""
     },
     {
-      "name": "\"incomplete competition (not all pairs have played)\"",
+      "name": "incomplete competition (not all pairs have played)",
       "cmd": "bash tournament.sh \"$INPUT_FILE\""
     },
     {
-      "name": "\"ties broken alphabetically\"",
+      "name": "ties broken alphabetically",
       "cmd": "bash tournament.sh <<< \"$input\""
     }
   ]

--- a/exercises/transpose/.meta/config.json
+++ b/exercises/transpose/.meta/config.json
@@ -1,0 +1,51 @@
+{
+  "solution_files": [
+    "transpose.sh"
+  ],
+  "tests": [
+    {
+      "name": "empty string",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "two characters in a row",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "two characters in a column",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "simple",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "single line",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "first line longer than second line",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "second line longer than first line",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "mixed line length",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "square",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "rectangle",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    },
+    {
+      "name": "triangle",
+      "cmd": "bash transpose.sh <<< \"$input\""
+    }
+  ]
+}

--- a/exercises/triangle/.meta/config.json
+++ b/exercises/triangle/.meta/config.json
@@ -1,0 +1,83 @@
+{
+  "solution_files": [
+    "triangle.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"all sides are equal, equilateral\"",
+      "cmd": "bash triangle.sh equilateral 2 2 2"
+    },
+    {
+      "name": "\"any side is unequal\"",
+      "cmd": "bash triangle.sh equilateral 2 3 2"
+    },
+    {
+      "name": "\"no sides are equal, equilateral\"",
+      "cmd": "bash triangle.sh equilateral 5 4 6"
+    },
+    {
+      "name": "\"all zero sides is not a triangle\"",
+      "cmd": "bash triangle.sh equilateral 0 0 0"
+    },
+    {
+      "name": "\"sides may be floats, equilateral\"",
+      "cmd": "bash triangle.sh equilateral 0.5 0.5 0.5"
+    },
+    {
+      "name": "\"last two sides are equal\"",
+      "cmd": "bash triangle.sh isosceles 3 4 4"
+    },
+    {
+      "name": "\"first two sides are equal\"",
+      "cmd": "bash triangle.sh isosceles 4 4 3"
+    },
+    {
+      "name": "\"first and last sides are equal\"",
+      "cmd": "bash triangle.sh isosceles 4 3 4"
+    },
+    {
+      "name": "\"equilateral triangles are also isosceles\"",
+      "cmd": "bash triangle.sh isosceles 4 4 4"
+    },
+    {
+      "name": "\"no sides are equal, isosceles\"",
+      "cmd": "bash triangle.sh isosceles 2 3 4"
+    },
+    {
+      "name": "\"first triangle inequality violation\"",
+      "cmd": "bash triangle.sh isosceles 1 1 3"
+    },
+    {
+      "name": "\"second triangle inequality violation\"",
+      "cmd": "bash triangle.sh isosceles 1 3 1"
+    },
+    {
+      "name": "\"third triangle inequality violation\"",
+      "cmd": "bash triangle.sh isosceles 3 1 1"
+    },
+    {
+      "name": "\"sides may be floats, isosceles\"",
+      "cmd": "bash triangle.sh isosceles 0.5 0.4 0.5"
+    },
+    {
+      "name": "\"no sides are equal, scalene\"",
+      "cmd": "bash triangle.sh scalene 5 4 6"
+    },
+    {
+      "name": "\"all sides are equal, scalene\"",
+      "cmd": "bash triangle.sh scalene 4 4 4"
+    },
+    {
+      "name": "\"two sides are equal\"",
+      "cmd": "bash triangle.sh scalene 4 4 3"
+    },
+    {
+      "name": "\"may not violate triangle inequality\"",
+      "cmd": "bash triangle.sh scalene 7 3 2"
+    },
+    {
+      "name": "\"sides may be floats, scalene\"",
+      "cmd": "bash triangle.sh scalene 0.5 0.4 0.6"
+    }
+  ]
+}

--- a/exercises/triangle/.meta/config.json
+++ b/exercises/triangle/.meta/config.json
@@ -4,79 +4,79 @@
   ],
   "tests": [
     {
-      "name": "\"all sides are equal, equilateral\"",
+      "name": "all sides are equal, equilateral",
       "cmd": "bash triangle.sh equilateral 2 2 2"
     },
     {
-      "name": "\"any side is unequal\"",
+      "name": "any side is unequal",
       "cmd": "bash triangle.sh equilateral 2 3 2"
     },
     {
-      "name": "\"no sides are equal, equilateral\"",
+      "name": "no sides are equal, equilateral",
       "cmd": "bash triangle.sh equilateral 5 4 6"
     },
     {
-      "name": "\"all zero sides is not a triangle\"",
+      "name": "all zero sides is not a triangle",
       "cmd": "bash triangle.sh equilateral 0 0 0"
     },
     {
-      "name": "\"sides may be floats, equilateral\"",
+      "name": "sides may be floats, equilateral",
       "cmd": "bash triangle.sh equilateral 0.5 0.5 0.5"
     },
     {
-      "name": "\"last two sides are equal\"",
+      "name": "last two sides are equal",
       "cmd": "bash triangle.sh isosceles 3 4 4"
     },
     {
-      "name": "\"first two sides are equal\"",
+      "name": "first two sides are equal",
       "cmd": "bash triangle.sh isosceles 4 4 3"
     },
     {
-      "name": "\"first and last sides are equal\"",
+      "name": "first and last sides are equal",
       "cmd": "bash triangle.sh isosceles 4 3 4"
     },
     {
-      "name": "\"equilateral triangles are also isosceles\"",
+      "name": "equilateral triangles are also isosceles",
       "cmd": "bash triangle.sh isosceles 4 4 4"
     },
     {
-      "name": "\"no sides are equal, isosceles\"",
+      "name": "no sides are equal, isosceles",
       "cmd": "bash triangle.sh isosceles 2 3 4"
     },
     {
-      "name": "\"first triangle inequality violation\"",
+      "name": "first triangle inequality violation",
       "cmd": "bash triangle.sh isosceles 1 1 3"
     },
     {
-      "name": "\"second triangle inequality violation\"",
+      "name": "second triangle inequality violation",
       "cmd": "bash triangle.sh isosceles 1 3 1"
     },
     {
-      "name": "\"third triangle inequality violation\"",
+      "name": "third triangle inequality violation",
       "cmd": "bash triangle.sh isosceles 3 1 1"
     },
     {
-      "name": "\"sides may be floats, isosceles\"",
+      "name": "sides may be floats, isosceles",
       "cmd": "bash triangle.sh isosceles 0.5 0.4 0.5"
     },
     {
-      "name": "\"no sides are equal, scalene\"",
+      "name": "no sides are equal, scalene",
       "cmd": "bash triangle.sh scalene 5 4 6"
     },
     {
-      "name": "\"all sides are equal, scalene\"",
+      "name": "all sides are equal, scalene",
       "cmd": "bash triangle.sh scalene 4 4 4"
     },
     {
-      "name": "\"two sides are equal\"",
+      "name": "two sides are equal",
       "cmd": "bash triangle.sh scalene 4 4 3"
     },
     {
-      "name": "\"may not violate triangle inequality\"",
+      "name": "may not violate triangle inequality",
       "cmd": "bash triangle.sh scalene 7 3 2"
     },
     {
-      "name": "\"sides may be floats, scalene\"",
+      "name": "sides may be floats, scalene",
       "cmd": "bash triangle.sh scalene 0.5 0.4 0.6"
     }
   ]

--- a/exercises/twelve-days/.meta/config.json
+++ b/exercises/twelve-days/.meta/config.json
@@ -4,63 +4,63 @@
   ],
   "tests": [
     {
-      "name": "\"first day a partridge in a pear tree\"",
+      "name": "first day a partridge in a pear tree",
       "cmd": "bash twelve_days.sh 1 1"
     },
     {
-      "name": "\"second day two turtle doves\"",
+      "name": "second day two turtle doves",
       "cmd": "bash twelve_days.sh 2 2"
     },
     {
-      "name": "\"third day three french hens\"",
+      "name": "third day three french hens",
       "cmd": "bash twelve_days.sh 3 3"
     },
     {
-      "name": "\"fourth day four calling birds\"",
+      "name": "fourth day four calling birds",
       "cmd": "bash twelve_days.sh 4 4"
     },
     {
-      "name": "\"fifth day five gold rings\"",
+      "name": "fifth day five gold rings",
       "cmd": "bash twelve_days.sh 5 5"
     },
     {
-      "name": "\"sixth day six geese-a-laying\"",
+      "name": "sixth day six geese-a-laying",
       "cmd": "bash twelve_days.sh 6 6"
     },
     {
-      "name": "\"seventh day seven swans-a-swimming\"",
+      "name": "seventh day seven swans-a-swimming",
       "cmd": "bash twelve_days.sh 7 7"
     },
     {
-      "name": "\"eighth day eight maids-a-milking\"",
+      "name": "eighth day eight maids-a-milking",
       "cmd": "bash twelve_days.sh 8 8"
     },
     {
-      "name": "\"ninth day nine ladies dancing\"",
+      "name": "ninth day nine ladies dancing",
       "cmd": "bash twelve_days.sh 9 9"
     },
     {
-      "name": "\"tenth day ten lords-a-leaping\"",
+      "name": "tenth day ten lords-a-leaping",
       "cmd": "bash twelve_days.sh 10 10"
     },
     {
-      "name": "\"eleventh day eleven pipers piping\"",
+      "name": "eleventh day eleven pipers piping",
       "cmd": "bash twelve_days.sh 11 11"
     },
     {
-      "name": "\"twelfth day twelve drummers drumming\"",
+      "name": "twelfth day twelve drummers drumming",
       "cmd": "bash twelve_days.sh 12 12"
     },
     {
-      "name": "\"recites first three verses of the song\"",
+      "name": "recites first three verses of the song",
       "cmd": "bash twelve_days.sh 1 3"
     },
     {
-      "name": "\"recites three verses from the middle of the song\"",
+      "name": "recites three verses from the middle of the song",
       "cmd": "bash twelve_days.sh 4 6"
     },
     {
-      "name": "\"recites the whole song\"",
+      "name": "recites the whole song",
       "cmd": "bash twelve_days.sh 1 12"
     }
   ]

--- a/exercises/twelve-days/.meta/config.json
+++ b/exercises/twelve-days/.meta/config.json
@@ -1,0 +1,67 @@
+{
+  "solution_files": [
+    "twelve_days.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"first day a partridge in a pear tree\"",
+      "cmd": "bash twelve_days.sh 1 1"
+    },
+    {
+      "name": "\"second day two turtle doves\"",
+      "cmd": "bash twelve_days.sh 2 2"
+    },
+    {
+      "name": "\"third day three french hens\"",
+      "cmd": "bash twelve_days.sh 3 3"
+    },
+    {
+      "name": "\"fourth day four calling birds\"",
+      "cmd": "bash twelve_days.sh 4 4"
+    },
+    {
+      "name": "\"fifth day five gold rings\"",
+      "cmd": "bash twelve_days.sh 5 5"
+    },
+    {
+      "name": "\"sixth day six geese-a-laying\"",
+      "cmd": "bash twelve_days.sh 6 6"
+    },
+    {
+      "name": "\"seventh day seven swans-a-swimming\"",
+      "cmd": "bash twelve_days.sh 7 7"
+    },
+    {
+      "name": "\"eighth day eight maids-a-milking\"",
+      "cmd": "bash twelve_days.sh 8 8"
+    },
+    {
+      "name": "\"ninth day nine ladies dancing\"",
+      "cmd": "bash twelve_days.sh 9 9"
+    },
+    {
+      "name": "\"tenth day ten lords-a-leaping\"",
+      "cmd": "bash twelve_days.sh 10 10"
+    },
+    {
+      "name": "\"eleventh day eleven pipers piping\"",
+      "cmd": "bash twelve_days.sh 11 11"
+    },
+    {
+      "name": "\"twelfth day twelve drummers drumming\"",
+      "cmd": "bash twelve_days.sh 12 12"
+    },
+    {
+      "name": "\"recites first three verses of the song\"",
+      "cmd": "bash twelve_days.sh 1 3"
+    },
+    {
+      "name": "\"recites three verses from the middle of the song\"",
+      "cmd": "bash twelve_days.sh 4 6"
+    },
+    {
+      "name": "\"recites the whole song\"",
+      "cmd": "bash twelve_days.sh 1 12"
+    }
+  ]
+}

--- a/exercises/two-bucket/.meta/config.json
+++ b/exercises/two-bucket/.meta/config.json
@@ -1,0 +1,39 @@
+{
+  "solution_files": [
+    "two_bucket.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one\"",
+      "cmd": "bash two_bucket.sh 3 5 1 \"one\""
+    },
+    {
+      "name": "\"Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two\"",
+      "cmd": "bash two_bucket.sh 3 5 1 \"two\""
+    },
+    {
+      "name": "\"Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one\"",
+      "cmd": "bash two_bucket.sh 7 11 2 \"one\""
+    },
+    {
+      "name": "\"Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two\"",
+      "cmd": "bash two_bucket.sh 7 11 2 \"two\""
+    },
+    {
+      "name": "\"Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two\"",
+      "cmd": "bash two_bucket.sh 1 3 3 \"two\""
+    },
+    {
+      "name": "\"Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two\"",
+      "cmd": "bash two_bucket.sh 2 3 3 \"one\""
+    },
+    {
+      "name": "\"goal is too big for the buckets\"",
+      "cmd": "bash two_bucket.sh 1 2 3 \"one\""
+    },
+    {
+      "name": "\"cannot satisfy the goal\"",
+      "cmd": "bash two_bucket.sh 6 8 3 \"one\""
+    }
+  ]
+}

--- a/exercises/two-bucket/.meta/config.json
+++ b/exercises/two-bucket/.meta/config.json
@@ -4,35 +4,35 @@
   ],
   "tests": [
     {
-      "name": "\"Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one\"",
+      "name": "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one",
       "cmd": "bash two_bucket.sh 3 5 1 \"one\""
     },
     {
-      "name": "\"Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two\"",
+      "name": "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two",
       "cmd": "bash two_bucket.sh 3 5 1 \"two\""
     },
     {
-      "name": "\"Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one\"",
+      "name": "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one",
       "cmd": "bash two_bucket.sh 7 11 2 \"one\""
     },
     {
-      "name": "\"Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two\"",
+      "name": "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two",
       "cmd": "bash two_bucket.sh 7 11 2 \"two\""
     },
     {
-      "name": "\"Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two\"",
+      "name": "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two",
       "cmd": "bash two_bucket.sh 1 3 3 \"two\""
     },
     {
-      "name": "\"Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two\"",
+      "name": "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two",
       "cmd": "bash two_bucket.sh 2 3 3 \"one\""
     },
     {
-      "name": "\"goal is too big for the buckets\"",
+      "name": "goal is too big for the buckets",
       "cmd": "bash two_bucket.sh 1 2 3 \"one\""
     },
     {
-      "name": "\"cannot satisfy the goal\"",
+      "name": "cannot satisfy the goal",
       "cmd": "bash two_bucket.sh 6 8 3 \"one\""
     }
   ]

--- a/exercises/two-fer/.meta/config.json
+++ b/exercises/two-fer/.meta/config.json
@@ -4,23 +4,23 @@
   ],
   "tests": [
     {
-      "name": "\"no name given\"",
-      "cmd": "bash two_fer.sh"
+      "name": "no name given",
+      "cmd": "line to run the test when you are ready."
     },
     {
-      "name": "\"a name given\"",
+      "name": "a name given",
       "cmd": "bash two_fer.sh Alice"
     },
     {
-      "name": "\"another name given\"",
+      "name": "another name given",
       "cmd": "bash two_fer.sh Bob"
     },
     {
-      "name": "\"handle arg with spaces\"",
+      "name": "handle arg with spaces",
       "cmd": "bash two_fer.sh \"John Smith\" \"Mary Ann\""
     },
     {
-      "name": "\"handle arg with glob char\"",
+      "name": "handle arg with glob char",
       "cmd": "bash two_fer.sh \"*\""
     }
   ]

--- a/exercises/two-fer/.meta/config.json
+++ b/exercises/two-fer/.meta/config.json
@@ -1,0 +1,27 @@
+{
+  "solution_files": [
+    "two_fer.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"no name given\"",
+      "cmd": "bash two_fer.sh"
+    },
+    {
+      "name": "\"a name given\"",
+      "cmd": "bash two_fer.sh Alice"
+    },
+    {
+      "name": "\"another name given\"",
+      "cmd": "bash two_fer.sh Bob"
+    },
+    {
+      "name": "\"handle arg with spaces\"",
+      "cmd": "bash two_fer.sh \"John Smith\" \"Mary Ann\""
+    },
+    {
+      "name": "\"handle arg with glob char\"",
+      "cmd": "bash two_fer.sh \"*\""
+    }
+  ]
+}

--- a/exercises/variable-length-quantity/.meta/config.json
+++ b/exercises/variable-length-quantity/.meta/config.json
@@ -1,0 +1,115 @@
+{
+  "solution_files": [
+    "variable_length_quantity.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"zero\"",
+      "cmd": "bash variable_length_quantity.sh encode 00"
+    },
+    {
+      "name": "\"arbitrary single byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 40"
+    },
+    {
+      "name": "\"largest single byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 7F"
+    },
+    {
+      "name": "\"smallest double byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 80"
+    },
+    {
+      "name": "\"arbitrary double byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 2000"
+    },
+    {
+      "name": "\"largest double byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 3FFF"
+    },
+    {
+      "name": "\"smallest triple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 4000"
+    },
+    {
+      "name": "\"arbitrary triple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 100000"
+    },
+    {
+      "name": "\"largest triple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 1FFFFF"
+    },
+    {
+      "name": "\"smallest quadruple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 200000"
+    },
+    {
+      "name": "\"arbitrary quadruple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 8000000"
+    },
+    {
+      "name": "\"largest quadruple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode FFFFFFF"
+    },
+    {
+      "name": "\"smallest quintuple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode 10000000"
+    },
+    {
+      "name": "\"arbitrary quintuple byte\"",
+      "cmd": "bash variable_length_quantity.sh encode FF000000"
+    },
+    {
+      "name": "\"maximum 32-bit integer input\"",
+      "cmd": "bash variable_length_quantity.sh encode FFFFFFFF"
+    },
+    {
+      "name": "\"two single-byte values\"",
+      "cmd": "bash variable_length_quantity.sh encode 40 7F"
+    },
+    {
+      "name": "\"two multi-byte values\"",
+      "cmd": "bash variable_length_quantity.sh encode 4000 123456"
+    },
+    {
+      "name": "\"many multi-byte values\"",
+      "cmd": "bash variable_length_quantity.sh encode 2000 123456 FFFFFFF 00 3FFF 4000"
+    },
+    {
+      "name": "\"one byte\"",
+      "cmd": "bash variable_length_quantity.sh decode 7F"
+    },
+    {
+      "name": "\"two bytes\"",
+      "cmd": "bash variable_length_quantity.sh decode C0 00"
+    },
+    {
+      "name": "\"three bytes\"",
+      "cmd": "bash variable_length_quantity.sh decode FF FF 7F"
+    },
+    {
+      "name": "\"four bytes\"",
+      "cmd": "bash variable_length_quantity.sh decode 81 80 80 00"
+    },
+    {
+      "name": "\"maximum 32-bit integer\"",
+      "cmd": "bash variable_length_quantity.sh decode 8F FF FF FF 7F"
+    },
+    {
+      "name": "\"multiple values\"",
+      "cmd": "bash variable_length_quantity.sh decode C0 00 C8 E8 56 FF FF FF 7F 00 FF 7F 81 80 00"
+    },
+    {
+      "name": "\"incomplete sequence causes error\"",
+      "cmd": "bash variable_length_quantity.sh decode FF"
+    },
+    {
+      "name": "\"incomplete sequence causes error, even if value is zero\"",
+      "cmd": "bash variable_length_quantity.sh decode 80"
+    },
+    {
+      "name": "\"invalid subcommand\"",
+      "cmd": "bash variable_length_quantity.sh hello 80"
+    }
+  ]
+}

--- a/exercises/variable-length-quantity/.meta/config.json
+++ b/exercises/variable-length-quantity/.meta/config.json
@@ -4,111 +4,111 @@
   ],
   "tests": [
     {
-      "name": "\"zero\"",
+      "name": "zero",
       "cmd": "bash variable_length_quantity.sh encode 00"
     },
     {
-      "name": "\"arbitrary single byte\"",
+      "name": "arbitrary single byte",
       "cmd": "bash variable_length_quantity.sh encode 40"
     },
     {
-      "name": "\"largest single byte\"",
+      "name": "largest single byte",
       "cmd": "bash variable_length_quantity.sh encode 7F"
     },
     {
-      "name": "\"smallest double byte\"",
+      "name": "smallest double byte",
       "cmd": "bash variable_length_quantity.sh encode 80"
     },
     {
-      "name": "\"arbitrary double byte\"",
+      "name": "arbitrary double byte",
       "cmd": "bash variable_length_quantity.sh encode 2000"
     },
     {
-      "name": "\"largest double byte\"",
+      "name": "largest double byte",
       "cmd": "bash variable_length_quantity.sh encode 3FFF"
     },
     {
-      "name": "\"smallest triple byte\"",
+      "name": "smallest triple byte",
       "cmd": "bash variable_length_quantity.sh encode 4000"
     },
     {
-      "name": "\"arbitrary triple byte\"",
+      "name": "arbitrary triple byte",
       "cmd": "bash variable_length_quantity.sh encode 100000"
     },
     {
-      "name": "\"largest triple byte\"",
+      "name": "largest triple byte",
       "cmd": "bash variable_length_quantity.sh encode 1FFFFF"
     },
     {
-      "name": "\"smallest quadruple byte\"",
+      "name": "smallest quadruple byte",
       "cmd": "bash variable_length_quantity.sh encode 200000"
     },
     {
-      "name": "\"arbitrary quadruple byte\"",
+      "name": "arbitrary quadruple byte",
       "cmd": "bash variable_length_quantity.sh encode 8000000"
     },
     {
-      "name": "\"largest quadruple byte\"",
+      "name": "largest quadruple byte",
       "cmd": "bash variable_length_quantity.sh encode FFFFFFF"
     },
     {
-      "name": "\"smallest quintuple byte\"",
+      "name": "smallest quintuple byte",
       "cmd": "bash variable_length_quantity.sh encode 10000000"
     },
     {
-      "name": "\"arbitrary quintuple byte\"",
+      "name": "arbitrary quintuple byte",
       "cmd": "bash variable_length_quantity.sh encode FF000000"
     },
     {
-      "name": "\"maximum 32-bit integer input\"",
+      "name": "maximum 32-bit integer input",
       "cmd": "bash variable_length_quantity.sh encode FFFFFFFF"
     },
     {
-      "name": "\"two single-byte values\"",
+      "name": "two single-byte values",
       "cmd": "bash variable_length_quantity.sh encode 40 7F"
     },
     {
-      "name": "\"two multi-byte values\"",
+      "name": "two multi-byte values",
       "cmd": "bash variable_length_quantity.sh encode 4000 123456"
     },
     {
-      "name": "\"many multi-byte values\"",
+      "name": "many multi-byte values",
       "cmd": "bash variable_length_quantity.sh encode 2000 123456 FFFFFFF 00 3FFF 4000"
     },
     {
-      "name": "\"one byte\"",
+      "name": "one byte",
       "cmd": "bash variable_length_quantity.sh decode 7F"
     },
     {
-      "name": "\"two bytes\"",
+      "name": "two bytes",
       "cmd": "bash variable_length_quantity.sh decode C0 00"
     },
     {
-      "name": "\"three bytes\"",
+      "name": "three bytes",
       "cmd": "bash variable_length_quantity.sh decode FF FF 7F"
     },
     {
-      "name": "\"four bytes\"",
+      "name": "four bytes",
       "cmd": "bash variable_length_quantity.sh decode 81 80 80 00"
     },
     {
-      "name": "\"maximum 32-bit integer\"",
+      "name": "maximum 32-bit integer",
       "cmd": "bash variable_length_quantity.sh decode 8F FF FF FF 7F"
     },
     {
-      "name": "\"multiple values\"",
+      "name": "multiple values",
       "cmd": "bash variable_length_quantity.sh decode C0 00 C8 E8 56 FF FF FF 7F 00 FF 7F 81 80 00"
     },
     {
-      "name": "\"incomplete sequence causes error\"",
+      "name": "incomplete sequence causes error",
       "cmd": "bash variable_length_quantity.sh decode FF"
     },
     {
-      "name": "\"incomplete sequence causes error, even if value is zero\"",
+      "name": "incomplete sequence causes error, even if value is zero",
       "cmd": "bash variable_length_quantity.sh decode 80"
     },
     {
-      "name": "\"invalid subcommand\"",
+      "name": "invalid subcommand",
       "cmd": "bash variable_length_quantity.sh hello 80"
     }
   ]

--- a/exercises/word-count/.meta/config.json
+++ b/exercises/word-count/.meta/config.json
@@ -4,59 +4,59 @@
   ],
   "tests": [
     {
-      "name": "\"count one word\"",
+      "name": "count one word",
       "cmd": "bash word_count.sh \"word\""
     },
     {
-      "name": "\"count one of each word\"",
+      "name": "count one of each word",
       "cmd": "bash word_count.sh \"one of each\""
     },
     {
-      "name": "\"multiple occurrences of a word\"",
+      "name": "multiple occurrences of a word",
       "cmd": "bash word_count.sh \"one fish two fish red fish blue fish\""
     },
     {
-      "name": "\"handles cramped lists\"",
+      "name": "handles cramped lists",
       "cmd": "bash word_count.sh \"one,two,three\""
     },
     {
-      "name": "\"handles expanded lists\"",
+      "name": "handles expanded lists",
       "cmd": "bash word_count.sh \"one,\\ntwo,\\nthree\""
     },
     {
-      "name": "\"ignore punctuation\"",
+      "name": "ignore punctuation",
       "cmd": "bash word_count.sh \"car: carpet as java: javascript!!&@$%^&\""
     },
     {
-      "name": "\"include numbers\"",
+      "name": "include numbers",
       "cmd": "bash word_count.sh \"testing, 1, 2 testing\""
     },
     {
-      "name": "\"normalize case\"",
+      "name": "normalize case",
       "cmd": "bash word_count.sh \"go Go GO Stop stop\""
     },
     {
-      "name": "\"with apostrophes\"",
+      "name": "with apostrophes",
       "cmd": "bash word_count.sh \"First: don't laugh. Then: don't cry.\""
     },
     {
-      "name": "\"with quotations\"",
+      "name": "with quotations",
       "cmd": "bash word_count.sh \"Joe can't tell between 'large' and large.\""
     },
     {
-      "name": "\"substrings from the beginning\"",
+      "name": "substrings from the beginning",
       "cmd": "bash word_count.sh \"Joe can't tell between apple, app and a.\""
     },
     {
-      "name": "\"multiple spaces not detected as a word\"",
+      "name": "multiple spaces not detected as a word",
       "cmd": "bash word_count.sh \" multiple whitespaces\""
     },
     {
-      "name": "\"alternating word separators are not detected as a word\"",
+      "name": "alternating word separators are not detected as a word",
       "cmd": "bash word_count.sh $',\\n,one,\\n ,two \\n \\'three\\''"
     },
     {
-      "name": "\"contains shell globbing character\"",
+      "name": "contains shell globbing character",
       "cmd": "bash word_count.sh \"two * words\""
     }
   ]

--- a/exercises/word-count/.meta/config.json
+++ b/exercises/word-count/.meta/config.json
@@ -1,0 +1,63 @@
+{
+  "solution_files": [
+    "word_count.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"count one word\"",
+      "cmd": "bash word_count.sh \"word\""
+    },
+    {
+      "name": "\"count one of each word\"",
+      "cmd": "bash word_count.sh \"one of each\""
+    },
+    {
+      "name": "\"multiple occurrences of a word\"",
+      "cmd": "bash word_count.sh \"one fish two fish red fish blue fish\""
+    },
+    {
+      "name": "\"handles cramped lists\"",
+      "cmd": "bash word_count.sh \"one,two,three\""
+    },
+    {
+      "name": "\"handles expanded lists\"",
+      "cmd": "bash word_count.sh \"one,\\ntwo,\\nthree\""
+    },
+    {
+      "name": "\"ignore punctuation\"",
+      "cmd": "bash word_count.sh \"car: carpet as java: javascript!!&@$%^&\""
+    },
+    {
+      "name": "\"include numbers\"",
+      "cmd": "bash word_count.sh \"testing, 1, 2 testing\""
+    },
+    {
+      "name": "\"normalize case\"",
+      "cmd": "bash word_count.sh \"go Go GO Stop stop\""
+    },
+    {
+      "name": "\"with apostrophes\"",
+      "cmd": "bash word_count.sh \"First: don't laugh. Then: don't cry.\""
+    },
+    {
+      "name": "\"with quotations\"",
+      "cmd": "bash word_count.sh \"Joe can't tell between 'large' and large.\""
+    },
+    {
+      "name": "\"substrings from the beginning\"",
+      "cmd": "bash word_count.sh \"Joe can't tell between apple, app and a.\""
+    },
+    {
+      "name": "\"multiple spaces not detected as a word\"",
+      "cmd": "bash word_count.sh \" multiple whitespaces\""
+    },
+    {
+      "name": "\"alternating word separators are not detected as a word\"",
+      "cmd": "bash word_count.sh $',\\n,one,\\n ,two \\n \\'three\\''"
+    },
+    {
+      "name": "\"contains shell globbing character\"",
+      "cmd": "bash word_count.sh \"two * words\""
+    }
+  ]
+}

--- a/exercises/wordy/.meta/config.json
+++ b/exercises/wordy/.meta/config.json
@@ -1,0 +1,107 @@
+{
+  "solution_files": [
+    "wordy.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"just a number\"",
+      "cmd": "bash wordy.sh \"What is 5?\""
+    },
+    {
+      "name": "\"addition\"",
+      "cmd": "bash wordy.sh \"What is 1 plus 1?\""
+    },
+    {
+      "name": "\"more addition\"",
+      "cmd": "bash wordy.sh \"What is 53 plus 2?\""
+    },
+    {
+      "name": "\"addition with negative numbers\"",
+      "cmd": "bash wordy.sh \"What is -1 plus -10?\""
+    },
+    {
+      "name": "\"large addition\"",
+      "cmd": "bash wordy.sh \"What is 123 plus 45678?\""
+    },
+    {
+      "name": "\"subtraction\"",
+      "cmd": "bash wordy.sh \"What is 4 minus -12?\""
+    },
+    {
+      "name": "\"multiplication\"",
+      "cmd": "bash wordy.sh \"What is -3 multiplied by 25?\""
+    },
+    {
+      "name": "\"division\"",
+      "cmd": "bash wordy.sh \"What is 33 divided by -3?\""
+    },
+    {
+      "name": "\"multiple additions\"",
+      "cmd": "bash wordy.sh \"What is 1 plus 1 plus 1?\""
+    },
+    {
+      "name": "\"addition and subtraction\"",
+      "cmd": "bash wordy.sh \"What is 1 plus 5 minus -2?\""
+    },
+    {
+      "name": "\"multiple subtraction\"",
+      "cmd": "bash wordy.sh \"What is 20 minus 4 minus 13?\""
+    },
+    {
+      "name": "\"subtraction then addition\"",
+      "cmd": "bash wordy.sh \"What is 17 minus 6 plus 3?\""
+    },
+    {
+      "name": "\"multiple multiplication\"",
+      "cmd": "bash wordy.sh \"What is 2 multiplied by -2 multiplied by 3?\""
+    },
+    {
+      "name": "\"addition and multiplication\"",
+      "cmd": "bash wordy.sh \"What is -3 plus 7 multiplied by -2?\""
+    },
+    {
+      "name": "\"multiple division\"",
+      "cmd": "bash wordy.sh \"What is -12 divided by 2 divided by -3?\""
+    },
+    {
+      "name": "\"strict left to right, ignores typical order of operations\"",
+      "cmd": "bash wordy.sh \"What is 2 plus 3 multiplied by 4?\""
+    },
+    {
+      "name": "\"unknown operation\"",
+      "cmd": "bash wordy.sh \"What is 52 cubed?\""
+    },
+    {
+      "name": "\"Non math question\"",
+      "cmd": "bash wordy.sh \"Who is the President of the United States?\""
+    },
+    {
+      "name": "\"reject problem with no operands\"",
+      "cmd": "bash wordy.sh \"What is plus?\""
+    },
+    {
+      "name": "\"reject problem missing an operand\"",
+      "cmd": "bash wordy.sh \"What is 1 plus?\""
+    },
+    {
+      "name": "\"reject problem with no operands or operators\"",
+      "cmd": "bash wordy.sh \"What is?\""
+    },
+    {
+      "name": "\"reject two operations in a row\"",
+      "cmd": "bash wordy.sh \"What is 1 plus plus 2?\""
+    },
+    {
+      "name": "\"reject two numbers in a row\"",
+      "cmd": "bash wordy.sh \"What is 1 plus 2 1?\""
+    },
+    {
+      "name": "\"reject postfix notation\"",
+      "cmd": "bash wordy.sh \"What is 1 2 plus?\""
+    },
+    {
+      "name": "\"reject prefix notation\"",
+      "cmd": "bash wordy.sh \"What is plus 1 2?\""
+    }
+  ]
+}

--- a/exercises/wordy/.meta/config.json
+++ b/exercises/wordy/.meta/config.json
@@ -4,103 +4,103 @@
   ],
   "tests": [
     {
-      "name": "\"just a number\"",
+      "name": "just a number",
       "cmd": "bash wordy.sh \"What is 5?\""
     },
     {
-      "name": "\"addition\"",
+      "name": "addition",
       "cmd": "bash wordy.sh \"What is 1 plus 1?\""
     },
     {
-      "name": "\"more addition\"",
+      "name": "more addition",
       "cmd": "bash wordy.sh \"What is 53 plus 2?\""
     },
     {
-      "name": "\"addition with negative numbers\"",
+      "name": "addition with negative numbers",
       "cmd": "bash wordy.sh \"What is -1 plus -10?\""
     },
     {
-      "name": "\"large addition\"",
+      "name": "large addition",
       "cmd": "bash wordy.sh \"What is 123 plus 45678?\""
     },
     {
-      "name": "\"subtraction\"",
+      "name": "subtraction",
       "cmd": "bash wordy.sh \"What is 4 minus -12?\""
     },
     {
-      "name": "\"multiplication\"",
+      "name": "multiplication",
       "cmd": "bash wordy.sh \"What is -3 multiplied by 25?\""
     },
     {
-      "name": "\"division\"",
+      "name": "division",
       "cmd": "bash wordy.sh \"What is 33 divided by -3?\""
     },
     {
-      "name": "\"multiple additions\"",
+      "name": "multiple additions",
       "cmd": "bash wordy.sh \"What is 1 plus 1 plus 1?\""
     },
     {
-      "name": "\"addition and subtraction\"",
+      "name": "addition and subtraction",
       "cmd": "bash wordy.sh \"What is 1 plus 5 minus -2?\""
     },
     {
-      "name": "\"multiple subtraction\"",
+      "name": "multiple subtraction",
       "cmd": "bash wordy.sh \"What is 20 minus 4 minus 13?\""
     },
     {
-      "name": "\"subtraction then addition\"",
+      "name": "subtraction then addition",
       "cmd": "bash wordy.sh \"What is 17 minus 6 plus 3?\""
     },
     {
-      "name": "\"multiple multiplication\"",
+      "name": "multiple multiplication",
       "cmd": "bash wordy.sh \"What is 2 multiplied by -2 multiplied by 3?\""
     },
     {
-      "name": "\"addition and multiplication\"",
+      "name": "addition and multiplication",
       "cmd": "bash wordy.sh \"What is -3 plus 7 multiplied by -2?\""
     },
     {
-      "name": "\"multiple division\"",
+      "name": "multiple division",
       "cmd": "bash wordy.sh \"What is -12 divided by 2 divided by -3?\""
     },
     {
-      "name": "\"strict left to right, ignores typical order of operations\"",
+      "name": "strict left to right, ignores typical order of operations",
       "cmd": "bash wordy.sh \"What is 2 plus 3 multiplied by 4?\""
     },
     {
-      "name": "\"unknown operation\"",
+      "name": "unknown operation",
       "cmd": "bash wordy.sh \"What is 52 cubed?\""
     },
     {
-      "name": "\"Non math question\"",
+      "name": "Non math question",
       "cmd": "bash wordy.sh \"Who is the President of the United States?\""
     },
     {
-      "name": "\"reject problem with no operands\"",
+      "name": "reject problem with no operands",
       "cmd": "bash wordy.sh \"What is plus?\""
     },
     {
-      "name": "\"reject problem missing an operand\"",
+      "name": "reject problem missing an operand",
       "cmd": "bash wordy.sh \"What is 1 plus?\""
     },
     {
-      "name": "\"reject problem with no operands or operators\"",
+      "name": "reject problem with no operands or operators",
       "cmd": "bash wordy.sh \"What is?\""
     },
     {
-      "name": "\"reject two operations in a row\"",
+      "name": "reject two operations in a row",
       "cmd": "bash wordy.sh \"What is 1 plus plus 2?\""
     },
     {
-      "name": "\"reject two numbers in a row\"",
+      "name": "reject two numbers in a row",
       "cmd": "bash wordy.sh \"What is 1 plus 2 1?\""
     },
     {
-      "name": "\"reject postfix notation\"",
+      "name": "reject postfix notation",
       "cmd": "bash wordy.sh \"What is 1 2 plus?\""
     },
     {
-      "name": "\"reject prefix notation\"",
+      "name": "reject prefix notation",
       "cmd": "bash wordy.sh \"What is plus 1 2?\""
     }
   ]

--- a/exercises/yacht/.meta/config.json
+++ b/exercises/yacht/.meta/config.json
@@ -1,0 +1,119 @@
+{
+  "solution_files": [
+    "yacht.sh"
+  ],
+  "tests": [
+    {
+      "name": "\"Yacht\"",
+      "cmd": "bash yacht.sh \"yacht\" 5 5 5 5 5"
+    },
+    {
+      "name": "\"Not Yacht\"",
+      "cmd": "bash yacht.sh \"yacht\" 1 3 3 2 5"
+    },
+    {
+      "name": "\"Ones\"",
+      "cmd": "bash yacht.sh \"ones\" 1 1 1 3 5"
+    },
+    {
+      "name": "\"Ones, out of order\"",
+      "cmd": "bash yacht.sh \"ones\" 3 1 1 5 1"
+    },
+    {
+      "name": "\"No ones\"",
+      "cmd": "bash yacht.sh \"ones\" 4 3 6 5 5"
+    },
+    {
+      "name": "\"Twos\"",
+      "cmd": "bash yacht.sh \"twos\" 2 3 4 5 6"
+    },
+    {
+      "name": "\"Fours\"",
+      "cmd": "bash yacht.sh \"fours\" 1 4 1 4 1"
+    },
+    {
+      "name": "\"Yacht counted as threes\"",
+      "cmd": "bash yacht.sh \"threes\" 3 3 3 3 3"
+    },
+    {
+      "name": "\"Yacht of 3s counted as fives\"",
+      "cmd": "bash yacht.sh \"fives\" 3 3 3 3 3"
+    },
+    {
+      "name": "\"Sixes\"",
+      "cmd": "bash yacht.sh \"sixes\" 2 3 4 5 6"
+    },
+    {
+      "name": "\"Full house two small, three big\"",
+      "cmd": "bash yacht.sh \"full house\" 2 2 4 4 4"
+    },
+    {
+      "name": "\"Full house three small, two big\"",
+      "cmd": "bash yacht.sh \"full house\" 5 3 3 5 3"
+    },
+    {
+      "name": "\"Two pair is not a full house\"",
+      "cmd": "bash yacht.sh \"full house\" 2 2 4 4 5"
+    },
+    {
+      "name": "\"Four of a kind is not a full house\"",
+      "cmd": "bash yacht.sh \"full house\" 1 4 4 4 4"
+    },
+    {
+      "name": "\"Yacht is not a full house\"",
+      "cmd": "bash yacht.sh \"full house\" 2 2 2 2 2"
+    },
+    {
+      "name": "\"Four of a Kind\"",
+      "cmd": "bash yacht.sh \"four of a kind\" 6 6 4 6 6"
+    },
+    {
+      "name": "\"Yacht can be scored as Four of a Kind\"",
+      "cmd": "bash yacht.sh \"four of a kind\" 3 3 3 3 3"
+    },
+    {
+      "name": "\"Full house is not Four of a Kind\"",
+      "cmd": "bash yacht.sh \"four of a kind\" 3 3 3 5 5"
+    },
+    {
+      "name": "\"Little Straight\"",
+      "cmd": "bash yacht.sh \"little straight\" 3 5 4 1 2"
+    },
+    {
+      "name": "\"Little Straight as Big Straight\"",
+      "cmd": "bash yacht.sh \"big straight\" 1 2 3 4 5"
+    },
+    {
+      "name": "\"Four in order but not a little straight\"",
+      "cmd": "bash yacht.sh \"little straight\" 1 1 2 3 4"
+    },
+    {
+      "name": "\"No pairs but not a little straight\"",
+      "cmd": "bash yacht.sh \"little straight\" 1 2 3 4 6"
+    },
+    {
+      "name": "\"Minimum is 1, maximum is 5, but not a little straight\"",
+      "cmd": "bash yacht.sh \"little straight\" 1 1 3 4 5"
+    },
+    {
+      "name": "\"Big Straight\"",
+      "cmd": "bash yacht.sh \"big straight\" 4 6 2 5 3"
+    },
+    {
+      "name": "\"Big Straight as little straight\"",
+      "cmd": "bash yacht.sh \"little straight\" 6 5 4 3 2"
+    },
+    {
+      "name": "\"No pairs but not a big straight\"",
+      "cmd": "bash yacht.sh \"big straight\" 6 5 4 3 1"
+    },
+    {
+      "name": "\"Choice\"",
+      "cmd": "bash yacht.sh \"choice\" 3 3 5 6 6"
+    },
+    {
+      "name": "\"Yacht as choice\"",
+      "cmd": "bash yacht.sh \"choice\" 2 2 2 2 2"
+    }
+  ]
+}

--- a/exercises/yacht/.meta/config.json
+++ b/exercises/yacht/.meta/config.json
@@ -4,115 +4,115 @@
   ],
   "tests": [
     {
-      "name": "\"Yacht\"",
+      "name": "Yacht",
       "cmd": "bash yacht.sh \"yacht\" 5 5 5 5 5"
     },
     {
-      "name": "\"Not Yacht\"",
+      "name": "Not Yacht",
       "cmd": "bash yacht.sh \"yacht\" 1 3 3 2 5"
     },
     {
-      "name": "\"Ones\"",
+      "name": "Ones",
       "cmd": "bash yacht.sh \"ones\" 1 1 1 3 5"
     },
     {
-      "name": "\"Ones, out of order\"",
+      "name": "Ones, out of order",
       "cmd": "bash yacht.sh \"ones\" 3 1 1 5 1"
     },
     {
-      "name": "\"No ones\"",
+      "name": "No ones",
       "cmd": "bash yacht.sh \"ones\" 4 3 6 5 5"
     },
     {
-      "name": "\"Twos\"",
+      "name": "Twos",
       "cmd": "bash yacht.sh \"twos\" 2 3 4 5 6"
     },
     {
-      "name": "\"Fours\"",
+      "name": "Fours",
       "cmd": "bash yacht.sh \"fours\" 1 4 1 4 1"
     },
     {
-      "name": "\"Yacht counted as threes\"",
+      "name": "Yacht counted as threes",
       "cmd": "bash yacht.sh \"threes\" 3 3 3 3 3"
     },
     {
-      "name": "\"Yacht of 3s counted as fives\"",
+      "name": "Yacht of 3s counted as fives",
       "cmd": "bash yacht.sh \"fives\" 3 3 3 3 3"
     },
     {
-      "name": "\"Sixes\"",
+      "name": "Sixes",
       "cmd": "bash yacht.sh \"sixes\" 2 3 4 5 6"
     },
     {
-      "name": "\"Full house two small, three big\"",
+      "name": "Full house two small, three big",
       "cmd": "bash yacht.sh \"full house\" 2 2 4 4 4"
     },
     {
-      "name": "\"Full house three small, two big\"",
+      "name": "Full house three small, two big",
       "cmd": "bash yacht.sh \"full house\" 5 3 3 5 3"
     },
     {
-      "name": "\"Two pair is not a full house\"",
+      "name": "Two pair is not a full house",
       "cmd": "bash yacht.sh \"full house\" 2 2 4 4 5"
     },
     {
-      "name": "\"Four of a kind is not a full house\"",
+      "name": "Four of a kind is not a full house",
       "cmd": "bash yacht.sh \"full house\" 1 4 4 4 4"
     },
     {
-      "name": "\"Yacht is not a full house\"",
+      "name": "Yacht is not a full house",
       "cmd": "bash yacht.sh \"full house\" 2 2 2 2 2"
     },
     {
-      "name": "\"Four of a Kind\"",
+      "name": "Four of a Kind",
       "cmd": "bash yacht.sh \"four of a kind\" 6 6 4 6 6"
     },
     {
-      "name": "\"Yacht can be scored as Four of a Kind\"",
+      "name": "Yacht can be scored as Four of a Kind",
       "cmd": "bash yacht.sh \"four of a kind\" 3 3 3 3 3"
     },
     {
-      "name": "\"Full house is not Four of a Kind\"",
+      "name": "Full house is not Four of a Kind",
       "cmd": "bash yacht.sh \"four of a kind\" 3 3 3 5 5"
     },
     {
-      "name": "\"Little Straight\"",
+      "name": "Little Straight",
       "cmd": "bash yacht.sh \"little straight\" 3 5 4 1 2"
     },
     {
-      "name": "\"Little Straight as Big Straight\"",
+      "name": "Little Straight as Big Straight",
       "cmd": "bash yacht.sh \"big straight\" 1 2 3 4 5"
     },
     {
-      "name": "\"Four in order but not a little straight\"",
+      "name": "Four in order but not a little straight",
       "cmd": "bash yacht.sh \"little straight\" 1 1 2 3 4"
     },
     {
-      "name": "\"No pairs but not a little straight\"",
+      "name": "No pairs but not a little straight",
       "cmd": "bash yacht.sh \"little straight\" 1 2 3 4 6"
     },
     {
-      "name": "\"Minimum is 1, maximum is 5, but not a little straight\"",
+      "name": "Minimum is 1, maximum is 5, but not a little straight",
       "cmd": "bash yacht.sh \"little straight\" 1 1 3 4 5"
     },
     {
-      "name": "\"Big Straight\"",
+      "name": "Big Straight",
       "cmd": "bash yacht.sh \"big straight\" 4 6 2 5 3"
     },
     {
-      "name": "\"Big Straight as little straight\"",
+      "name": "Big Straight as little straight",
       "cmd": "bash yacht.sh \"little straight\" 6 5 4 3 2"
     },
     {
-      "name": "\"No pairs but not a big straight\"",
+      "name": "No pairs but not a big straight",
       "cmd": "bash yacht.sh \"big straight\" 6 5 4 3 1"
     },
     {
-      "name": "\"Choice\"",
+      "name": "Choice",
       "cmd": "bash yacht.sh \"choice\" 3 3 5 6 6"
     },
     {
-      "name": "\"Yacht as choice\"",
+      "name": "Yacht as choice",
       "cmd": "bash yacht.sh \"choice\" 2 2 2 2 2"
     }
   ]


### PR DESCRIPTION
<!-- Your content goes here: -->
This almost worked for all of them, but alas there are some edge cases that make it difficult to automate grabbing the run lines when there are multiple of them per test case. In such case my automated solution favored failing.

I could switch to an algorithm that builds along the way, but I still don't know exactly what we should do for the test cmd in such cases (since it is supposed to be a string not a list).

I will probably just have it use the first run string in cases with multiple per case.
Anyway, I figured I would let this draft go up here, but I should have all of them done tomorrow.

Closes #414 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
