### PR TITLE
Update bats-core installation via homebrew on OS X

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,9 +1,8 @@
 As there isn't much of a bash ecosystem, there also isn't really a defacto
 leader in the bash testing area. For these examples we are using
-[bats](https://github.com/bats-core/bats-core) (this repo was forked from
-[the original bats](https://github.com/sstephenson/bats) which has
-stagnated).  You should be able to install it from your favorite package
-manager, on OS X with homebrew this would look something like this:
+[bats](https://github.com/bats-core/bats-core). You should be able to
+install it from your favorite package manager, on OS X with
+[Homebrew](https://brew.sh/) this would look something like this:
 
 ```
 $ brew install bats-core

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,14 +1,17 @@
-As there isn't much of a bash ecosystem, there also isn't really a defacto leader in the bash testing area. For these examples we are using [bats](https://github.com/sstephenson/bats). You should be able to install it from your favorite package manager, on OS X with homebrew this would look something like this:
+As there isn't much of a bash ecosystem, there also isn't really a defacto
+leader in the bash testing area. For these examples we are using
+[bats](https://github.com/bats-core/bats-core) (this repo was forked from
+[the original bats](https://github.com/sstephenson/bats) which has
+stagnated).  You should be able to install it from your favorite package
+manager, on OS X with homebrew this would look something like this:
 
 ```
-$ brew install bats
-==> Downloading
-https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz
-==> Downloading from
-https://codeload.github.com/sstephenson/bats/tar.gz/v0.4.0
+$ brew install bats-core
+==> Downloading https://github.com/bats-core/bats-core/archive/v1.1.0.tar.gz
+==> Downloading from https://codeload.github.com/bats-core/bats-core/tar.gz/v1.1.0
 ######################################################################## 100.0%
-==> ./install.sh /opt/boxen/homebrew/Cellar/bats/0.4.0
-/opt/boxen/homebrew/Cellar/bats/0.4.0: 10 files, 60K, built in 2 seconds  
+==> ./install.sh /usr/local/Cellar/bats-core/1.1.0
+🍺  /usr/local/Cellar/bats-core/1.1.0: 13 files, 55KB, built in 4 seconds
 ```
 
 For Ubuntu 15.10 or later  


### PR DESCRIPTION
<!-- Your content goes here: -->

Mac *only* change to demonstrate installing bats-core with homebrew. Ubuntu instructions untouched. 

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
