### PR TITLE
Update steps for Linux to install bats-core from source

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -15,7 +15,18 @@ $ brew install bats-core
 ```
 
 ### For Linux
-The implementation of `bats` we use is not conveniently packaged. The best way to install it is from source: if you want to install it under `/usr/local` then
+
+#### Fedora 30 and newer
+
+`bats` is packaged for Fedora 30 and newer, you can install it with
+
+```bash
+sudo dnf install bats
+```
+
+#### Other Linux
+
+For other Linux distributions the implementation of `bats` we use is not conveniently packaged. The best way to install it is from source: if you want to install it under `/usr/local` then
 ```bash
 git clone https://github.com/bats-core/bats-core
 cd bats-core/

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -14,14 +14,20 @@ $ brew install bats-core
 🍺  /usr/local/Cellar/bats-core/1.1.0: 13 files, 55KB, built in 4 seconds
 ```
 
-### For Ubuntu 15.10 or later  
+### For Linux
+The implementation of `bats` we use is not conveniently packaged. The best way to install it is from source: if you want to install it under `/usr/local` then
+```bash
+git clone https://github.com/bats-core/bats-core
+cd bats-core/
+sudo ./install.sh /usr/local
 ```
-sudo apt-get install bats  
+Following that, assuming `/usr/local/bin` is in your $PATH, you can now do:
 ```
-
-### For Red Hat, Scientific Linux, and CentOS 6 or later bats is found in the EPEL repository.  
-```
-sudo yum install bats  
+$ bats
+Error: Must specify at least one <test>
+Usage: bats [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
+       bats [-h | -v]
+...
 ```
 
 ### For Windows (MINGW64/Cygwin)


### PR DESCRIPTION
<!-- Your content goes here: -->
Since on Ubuntu, the `bats` package is the old sstephenson one.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
