### PR TITLE
Error-handling: usage tests do not reflect how script is invoked

### DIFF
--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -23,7 +23,7 @@
   run bash error_handling.sh Alice Bob
 
   [[ $status -eq 1 ]]
-  [[ $output = "Usage: error_handling.sh <greetee>" ]]
+  [[ $output = "Usage: error_handling.sh <person>" ]]
 }
 
 @test "print usage banner with no value given" {
@@ -31,7 +31,7 @@
   run bash error_handling.sh
 
   [[ $status -eq 1 ]]
-  [[ $output = "Usage: error_handling.sh <greetee>" ]]
+  [[ $output = "Usage: error_handling.sh <person>" ]]
 }
 
 @test "empty argument" {

--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# local version: <none>
+# local version: 0.0.1
 
 @test "correct arguments" {
   #[[ $BATS_RUN_SKIPPED == true  ]] || skip
@@ -23,7 +23,7 @@
   run bash error_handling.sh Alice Bob
 
   [[ $status -eq 1 ]]
-  [[ $output = "Usage: ./error_handling <greetee>" ]]
+  [[ $output = "Usage: error_handling.sh <greetee>" ]]
 }
 
 @test "print usage banner with no value given" {
@@ -31,7 +31,7 @@
   run bash error_handling.sh
 
   [[ $status -eq 1 ]]
-  [[ $output = "Usage: ./error_handling <greetee>" ]]
+  [[ $output = "Usage: error_handling.sh <greetee>" ]]
 }
 
 @test "empty argument" {

--- a/exercises/error-handling/example.sh
+++ b/exercises/error-handling/example.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o nounset
-
-if [ $# -ne 1 ]; then
-  echo "Usage: ./error_handling <greetee>"
+if (( $# != 1 )); then
+  echo "Usage: $0 <greetee>" >&2
   exit 1
-else
-  echo "Hello, ${1}"
-  exit 0
 fi
+
+echo "Hello, $1"

--- a/exercises/error-handling/example.sh
+++ b/exercises/error-handling/example.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if (( $# != 1 )); then
-  echo "Usage: $0 <greetee>" >&2
+  echo "Usage: $0 <person>" >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- Your content goes here: -->

I was mentoring a solution that used `echo "Usage: $0 <greetee>"` which
fails the incorrect usage tests "$output" tests. I think the tests need to
be changed to reflect (what I think is) the idiomatic use of "$0" in usage
messages.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
