### PR TITLE
Change references for bats to point to bats-core

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -15,7 +15,18 @@ $ brew install bats-core
 ```
 
 ### For Linux
-The implementation of `bats` we use is not conveniently packaged. The best way to install it is from source: if you want to install it under `/usr/local` then
+
+#### Fedora 30 and newer
+
+`bats` is packaged for Fedora 30 and newer, you can install it with
+
+```bash
+sudo dnf install bats
+```
+
+#### Other Linux
+
+For other Linux distributions the implementation of `bats` we use is not conveniently packaged. The best way to install it is from source: if you want to install it under `/usr/local` then
 ```bash
 git clone https://github.com/bats-core/bats-core
 cd bats-core/

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -14,14 +14,20 @@ $ brew install bats-core
 🍺  /usr/local/Cellar/bats-core/1.1.0: 13 files, 55KB, built in 4 seconds
 ```
 
-### For Ubuntu 15.10 or later  
+### For Linux
+The implementation of `bats` we use is not conveniently packaged. The best way to install it is from source: if you want to install it under `/usr/local` then
+```bash
+git clone https://github.com/bats-core/bats-core
+cd bats-core/
+sudo ./install.sh /usr/local
 ```
-sudo apt-get install bats  
+Following that, assuming `/usr/local/bin` is in your $PATH, you can now do:
 ```
-
-### For Red Hat, Scientific Linux, and CentOS 6 or later bats is found in the EPEL repository.  
-```
-sudo yum install bats  
+$ bats
+Error: Must specify at least one <test>
+Usage: bats [-cr] [-f <regex>] [-j <jobs>] [-p | -t] <test>...
+       bats [-h | -v]
+...
 ```
 
 ### For Windows (MINGW64/Cygwin)

--- a/exercises/hello-world/.meta/hints.md
+++ b/exercises/hello-world/.meta/hints.md
@@ -20,19 +20,19 @@ etc), you probably already have bash.
 
 As there isn't much of a bash ecosystem, there also isn't really a de
 facto leader in the bash testing area. For these examples we are using
-[bats](https://github.com/sstephenson/bats). You should be able to
+[bats](https://github.com/bats-core/bats-core). You should be able to
 install it from your favorite package manager, on OS X with homebrew
 this would look something like this:
 
 ```
 $ brew install bats
 ==> Downloading
-https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz
+https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz
 ==> Downloading from
-https://codeload.github.com/sstephenson/bats/tar.gz/v0.4.0
+https://codeload.github.com/bats-core/bats-core/tar.gz/v1.2.0
 ########################################################################
 100.0%
-==> ./install.sh /opt/boxen/homebrew/Cellar/bats/0.4.0
-🍺  /opt/boxen/homebrew/Cellar/bats/0.4.0: 10 files, 60K, built in 2
+==> ./install.sh /opt/boxen/homebrew/Cellar/bats/1.2.0
+🍺  /opt/boxen/homebrew/Cellar/bats/1.2.0: 10 files, 60K, built in 2
 seconds
 ```

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -36,20 +36,20 @@ etc), you probably already have bash.
 
 As there isn't much of a bash ecosystem, there also isn't really a de
 facto leader in the bash testing area. For these examples we are using
-[bats](https://github.com/sstephenson/bats). You should be able to
+[bats](https://github.com/bats-core/bats-core). You should be able to
 install it from your favorite package manager, on OS X with homebrew
 this would look something like this:
 
 ```
 $ brew install bats
 ==> Downloading
-https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz
+https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz
 ==> Downloading from
-https://codeload.github.com/sstephenson/bats/tar.gz/v0.4.0
+https://codeload.github.com/bats-core/bats-core/tar.gz/v1.2.0
 ########################################################################
 100.0%
-==> ./install.sh /opt/boxen/homebrew/Cellar/bats/0.4.0
-🍺  /opt/boxen/homebrew/Cellar/bats/0.4.0: 10 files, 60K, built in 2
+==> ./install.sh /opt/boxen/homebrew/Cellar/bats/1.2.0
+🍺  /opt/boxen/homebrew/Cellar/bats/1.2.0: 10 files, 60K, built in 2
 seconds
 ```
 


### PR DESCRIPTION
Looks like we had a forgotten branch from January where we started changing references to Bats to link to https://github.com/bats-core/bats-core

Added another commit to it and changing a few more references, prompted by https://github.com/exercism/bash/issues/438