### PR TITLE
Change references for bats to point to bats-core

### DIFF
--- a/exercises/hello-world/.meta/hints.md
+++ b/exercises/hello-world/.meta/hints.md
@@ -20,19 +20,19 @@ etc), you probably already have bash.
 
 As there isn't much of a bash ecosystem, there also isn't really a de
 facto leader in the bash testing area. For these examples we are using
-[bats](https://github.com/sstephenson/bats). You should be able to
+[bats](https://github.com/bats-core/bats-core). You should be able to
 install it from your favorite package manager, on OS X with homebrew
 this would look something like this:
 
 ```
 $ brew install bats
 ==> Downloading
-https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz
+https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz
 ==> Downloading from
-https://codeload.github.com/sstephenson/bats/tar.gz/v0.4.0
+https://codeload.github.com/bats-core/bats-core/tar.gz/v1.2.0
 ########################################################################
 100.0%
-==> ./install.sh /opt/boxen/homebrew/Cellar/bats/0.4.0
-🍺  /opt/boxen/homebrew/Cellar/bats/0.4.0: 10 files, 60K, built in 2
+==> ./install.sh /opt/boxen/homebrew/Cellar/bats/1.2.0
+🍺  /opt/boxen/homebrew/Cellar/bats/1.2.0: 10 files, 60K, built in 2
 seconds
 ```

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -36,20 +36,20 @@ etc), you probably already have bash.
 
 As there isn't much of a bash ecosystem, there also isn't really a de
 facto leader in the bash testing area. For these examples we are using
-[bats](https://github.com/sstephenson/bats). You should be able to
+[bats](https://github.com/bats-core/bats-core). You should be able to
 install it from your favorite package manager, on OS X with homebrew
 this would look something like this:
 
 ```
 $ brew install bats
 ==> Downloading
-https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz
+https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz
 ==> Downloading from
-https://codeload.github.com/sstephenson/bats/tar.gz/v0.4.0
+https://codeload.github.com/bats-core/bats-core/tar.gz/v1.2.0
 ########################################################################
 100.0%
-==> ./install.sh /opt/boxen/homebrew/Cellar/bats/0.4.0
-🍺  /opt/boxen/homebrew/Cellar/bats/0.4.0: 10 files, 60K, built in 2
+==> ./install.sh /opt/boxen/homebrew/Cellar/bats/1.2.0
+🍺  /opt/boxen/homebrew/Cellar/bats/1.2.0: 10 files, 60K, built in 2
 seconds
 ```
 


### PR DESCRIPTION
New less confusing merge request, changing remaining references to link to https://github.com/bats-core/bats-core

We have already been pointing people to the newer version since January, so this change just affects what's shown to people along with the Hello World exercise to match that.

I think that in reality, if they installed Bats from e.g. Ubuntu or Fedora lately, they would already be getting a Bats version 1.1 or newer from `bats-core` since some time, so I don't expect this will lead to any issues.

Closes #438 