### PR TITLE
Do something with the return status of the fetch_archive function

### DIFF
--- a/bin/fetch_configlet
+++ b/bin/fetch_configlet
@@ -50,11 +50,11 @@ fetch_archive() {
 
 case "$EXT" in
     zip)
-        fetch_archive "Zip archive data"
+        fetch_archive "Zip archive data" || exit 1
         unzip "$localfile" -d bin/
         ;;
     tgz)
-        fetch_archive "gzip compressed data"
+        fetch_archive "gzip compressed data" || exit 1
         tar xzf "$localfile" -C bin/
         ;;
 esac


### PR DESCRIPTION
<!-- Your content goes here: -->
I thought about putting the `rm -f "$localfile"` into a `trap cleanup EXIT` function, but I figured if there's some failure, it may be worthwhile being able to inspect what actually did get downloaded.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
