### PR TITLE
add "&&" to ensure "status" is included in test pass/fail

### DIFF
--- a/exercises/error-handling/error_handling_test.sh
+++ b/exercises/error-handling/error_handling_test.sh
@@ -6,7 +6,7 @@
   #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash error_handling.sh Alice
 
-  (( status == 0 ))
+  (( status == 0 )) &&
   [[ $output == "Hello, Alice" ]]
 }
 
@@ -14,7 +14,7 @@
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash error_handling.sh "Alice and Bob"
 
-  (( status == 0 ))
+  (( status == 0 )) &&
   [[ $output == "Hello, Alice and Bob" ]]
 }
 
@@ -22,7 +22,7 @@
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash error_handling.sh Alice Bob
 
-  (( status == 1 ))
+  (( status == 1 )) &&
   [[ $output == "Usage: error_handling.sh <person>" ]]
 }
 
@@ -30,7 +30,7 @@
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash error_handling.sh
 
-  (( status == 1 ))
+  (( status == 1 )) &&
   [[ $output == "Usage: error_handling.sh <person>" ]]
 }
 
@@ -38,6 +38,6 @@
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash error_handling.sh ""
 
-  (( status == 0 ))
+  (( status == 0 )) &&
   [[ $output == "Hello, " ]]
 }


### PR DESCRIPTION
## Summary: 
Core excercise number 3: "Error Handling"

Submitting the solution with all tests giving a result of "status code 0"

Two tests should have failed for this excercise:
```bash
@test "incorrect arguments" 
@test "print usage banner with no value given" 
```

With the addition of "&&" the test suite is correctly failing.

Happy to make alternative changes if preferred.

Additionally,
let me know if you want me to add this to all of the test suites for the bash track.

Below are images where the mentor spotted the excercise should have had a failing test suite.
Cheers, Michael Dimmitt 

![exercise-example](https://user-images.githubusercontent.com/11463275/93931209-81e56f80-fcec-11ea-80c8-9fc13df9b205.png)

![explanation](https://user-images.githubusercontent.com/11463275/93931340-aa6d6980-fcec-11ea-92ad-19d536d52ab4.png)

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
