### PR TITLE
Fix affine-cipher CI failures

### DIFF
--- a/exercises/affine-cipher/example.sh
+++ b/exercises/affine-cipher/example.sh
@@ -17,46 +17,43 @@ process () { #main encoding and decoding process
 
 }
 
-coprime_check () { #check coprimality of a and m
+abs() {
+  echo $(( $1 < 0 ? -1 * $1 : $1 ))
+}
 
-  check=$((a % 2))
-
-  if [ "$check" -ne 0 ]; then
-    for (( factor=3; factor<="$a"; factor+=2 )); do
-      if [[ $((a % factor)) -eq 0 && $((26 % factor)) -eq 0 ]]; then
-        echo "a and m must be coprime." && exit 1
-      fi
-    done #wish I could find a cleaner solution for this function
+gcd() {
+  local a; a=$(abs "$1")
+  local b; b=$(abs "$2")
+  if (( b > 0 )); then
+    gcd "$b" $((a % b))
   else
+    echo "$a"
+  fi
+}
+
+coprime_check () { #check coprimality of a and m
+  local m=${#alphabet[@]}
+  if (( $(gcd "$a" "$m") != 1 )); then
     echo "a and m must be coprime." && exit 1
   fi
+}
+
+main () {
+
+  alphabet=({a..z})
+
+  a="$2"
+  b="$3"
+  coprime_check
+
+  for i in "${!alphabet[@]}"; do #generate encoded pair for 'tr'
+    index=$((a * i + b))         #E(x) = (ax + b) mod m
+    index=$((index % 26))
+    cypherbet+="${alphabet[$index]}"
+  done
+
+  process "$1" "$4"
 
 }
 
-a="$2"; b="$3"
-
-for letter in {a..z}; do #generate the alphabet map
-  alphabet+=("$letter")
-done
-
-for i in "${!alphabet[@]}"; do #generate encoded pair for 'tr'
-  index=$((a * i + b))         #E(x) = (ax + b) mod m
-  index=$((index % 26))
-  cypherbet+="${alphabet[$index]}"
-done
-
-coprime_check
-
-if [ -p /dev/stdin ]; then
-  while IFS= read -r line; do
-    process "$1" "$line"
-  done
-elif [ -f "./$4" ]; then
-  while IFS= read -r line; do
-    process "$1" "$line"
-  done < "$4"
-else
-  process "$1" "$4"
-fi
-
-exit 0
+main "$@"


### PR DESCRIPTION
<!-- Your content goes here: -->
Remove extraneous checks to determine where to get data: just take parameters.  
Also, simplify the co-prime check as the code comments request.

Addresses issue #457 
<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
