### PR TITLE
Sync test cases with canonical data

### DIFF
--- a/exercises/two-bucket/.meta/tests.toml
+++ b/exercises/two-bucket/.meta/tests.toml
@@ -17,3 +17,12 @@
 
 # Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
 "eb329c63-5540-4735-b30b-97f7f4df0f84" = true
+
+# Not possible to reach the goal
+"449be72d-b10a-4f4b-a959-ca741e333b72" = true
+
+# With the same buckets but a different goal, then it is possible
+"aac38b7a-77f4-4d62-9b91-8846d533b054" = true
+
+# Goal larger than both buckets is impossible
+"74633132-0ccf-49de-8450-af4ab2e3b299" = true

--- a/exercises/two-bucket/two_bucket_test.sh
+++ b/exercises/two-bucket/two_bucket_test.sh
@@ -52,17 +52,24 @@
     [[ $output == "$expected" ]]
 }
 
-# error cases
-@test "goal is too big for the buckets" {
+@test "Not possible to reach the goal" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    run bash two_bucket.sh 1 2 3 "one"
-    [[ $status -ne 0 ]]
+    run bash two_bucket.sh 6 15 5 "one"
+    (( status == 1 ))
     [[ $output == *"invalid goal"* ]]
 }
 
-@test "cannot satisfy the goal" {
+@test "With the same buckets but a different goal, then it is possible" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    run bash two_bucket.sh 6 8 3 "one"
-    [[ $status -ne 0 ]]
+    expected="moves: 10, goalBucket: two, otherBucket: 0"
+    run bash two_bucket.sh 6 15 9 "one"
+    (( status == 0 ))
+    [[ $output == "$expected" ]]
+}
+
+@test "Goal larger than both buckets is impossible" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run bash two_bucket.sh 5 7 8 "one"
+    (( status == 1 ))
     [[ $output == *"invalid goal"* ]]
 }


### PR DESCRIPTION
<!-- Your content goes here: -->
The new canonical test cases were in part inspired by the bash-only checks.
Syncing this track as housekeeping.




<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
