### PR TITLE
Two-fer glob test improvement

### DIFF
--- a/exercises/two-fer/example.sh
+++ b/exercises/two-fer/example.sh
@@ -1,9 +1,3 @@
 #!/usr/bin/env bash
 
-if [ "$#" -eq 0 ]; then
-  person="you"
-else
-  person="$1"
-fi
-
-echo "One for $person, one for me."
+echo "One for ${1:-you}, one for me."

--- a/exercises/two-fer/two_fer_test.sh
+++ b/exercises/two-fer/two_fer_test.sh
@@ -50,7 +50,7 @@
 
 @test "handle arg with glob char" {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run bash two_fer.sh "*"
+  run bash two_fer.sh "* "
   (( status == 0 ))
-  [[ $output == "One for *, one for me." ]]
+  [[ $output == "One for * , one for me." ]]
 }


### PR DESCRIPTION
<!-- Your content goes here: -->

The existing glob test will only produce unusual results if there is a filename ending with a comma. Adding a space to the input will mane the incorrect output more obvious that quotes are missing.

Also, updated the example solution

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
