### PR TITLE
To fix tournament tests in CI without completely revamping the GHA workflows, ...

### DIFF
--- a/exercises/practice/tournament/tournament_test.sh
+++ b/exercises/practice/tournament/tournament_test.sh
@@ -8,7 +8,11 @@
 
 # uses external tool: mktemp
 
-setup()    { export INPUT_FILE=$( mktemp ); }
+setup() { 
+    export INPUT_FILE HAS_TTY
+    INPUT_FILE=$( mktemp ) 
+    [[ -t 0 ]] && HAS_TTY=1 || HAS_TTY=0
+}
 teardown() { rm -f "$INPUT_FILE"; }
 
 @test "just the header if no input" {
@@ -30,6 +34,8 @@ EXPECTED
 
 @test "a win is three points, a loss is zero points" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    # ignore this test in CI
+    (( HAS_TTY )) || skip
 
     cat <<INPUT >"$INPUT_FILE"
 Allegoric Alaskans;Blithering Badgers;win
@@ -201,6 +207,8 @@ EXPECTED
 
 @test "incomplete competition (not all pairs have played)" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    # ignore this test in CI
+    (( HAS_TTY )) || skip
 
     cat <<INPUT > "$INPUT_FILE"
 Allegoric Alaskans;Blithering Badgers;loss


### PR DESCRIPTION
<!-- Your content goes here: -->

... ignore tests that require a tty (those where input is fed on stdin)

As a side benefit, students might get curious about the `-t` test.

This is a dirty hack, to skip tests in CI.

Addresses issue #460 

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
