### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+# pull request template
+
 <!-- Your content goes here: -->
 
 

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Bash is the language that you will learn to love!
 
 Many of your everyday computer tasks can be done using the concise scripts

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 ## Linux
 
 Bash, as the GNU shell, will be found on any GNU/Linux system. 

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 Bash is a very powerful Unix shell and command scripting language. 
 The man page for Bash is a well written and informational document. 
 Additional guides, information, and examples can be found at 

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 - Bash man page: to view it, type `man bash` in a terminal.
 - [Bash Guide](http://mywiki.wooledge.org/BashGuide)
 - [Bash FAQ](http://mywiki.wooledge.org/BashFAQ)

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 As there isn't much of a bash ecosystem, there also isn't really a defacto
 leader in the bash testing area. For these examples we are using
 [bats](https://github.com/bats-core/bats-core). 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -10,7 +10,7 @@ cd /path/to/your/exercise_workspace/bash/whatever
 bats whatever_test.sh
 ```
 
-### Legacy `bats`
+## Legacy `bats`
 
 `bats-core` was forked from [the original `bats`
 implementation](https://github.com/sstephenson/bats).  The sstephenson/bats

--- a/exercises/practice/darts/.docs/instructions.append.md
+++ b/exercises/practice/darts/.docs/instructions.append.md
@@ -1,5 +1,4 @@
-# Instructions append
-
+# Floating Point Arithmetic
 
 This particular exercise, since it deals with floating point arithmetic, is
 natural to rely on external tools (see below). As an extra challenging

--- a/exercises/practice/darts/.docs/instructions.append.md
+++ b/exercises/practice/darts/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 
 This particular exercise, since it deals with floating point arithmetic, is
 natural to rely on external tools (see below). As an extra challenging

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,3 +1,5 @@
+# Instructions append
+
 ## Test-Driven Development
 
 As programmers mature, they eventually want to test their code.

--- a/exercises/practice/gigasecond/.docs/instructions.append.md
+++ b/exercises/practice/gigasecond/.docs/instructions.append.md
@@ -1,6 +1,4 @@
-# Instructions append
-
-## Test-Driven Development
+# Test-Driven Development
 
 As programmers mature, they eventually want to test their code.
 
@@ -13,7 +11,7 @@ the problem.
 It will also provide you with a safety net to explore other solutions without
 breaking the functionality.
 
-### A typical TDD workflow on Exercism:
+## A typical TDD workflow on Exercism:
 
 1. Run the test file and pick one test that's failing.
 2. Write some code to fix the test you picked.
@@ -21,7 +19,7 @@ breaking the functionality.
 4. Repeat from step 1.
 5. Submit your solution (`exercism submit /path/to/file`)
 
-## Instructions
+# Instructions
 
 Submissions are encouraged to be general, within reason. Having said that, it's
 also important not to over-engineer a solution.

--- a/exercises/practice/grep/.docs/instructions.append.md
+++ b/exercises/practice/grep/.docs/instructions.append.md
@@ -1,4 +1,4 @@
-## To `grep` or not to `grep`, that is the question
+# To `grep` or not to `grep`, that is the question
 
 Although this exercise can be trivially solved by simply passing the
 arguments to `grep`, implement this exercise using bash only.  The aim 


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
