### PR TITLE
Change brew install command to bats-core

### DIFF
--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -25,7 +25,7 @@ install it from your favorite package manager, on OS X with homebrew
 this would look something like this:
 
 ```
-$ brew install bats
+$ brew install bats-core
 ==> Downloading
 https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz
 ==> Downloading from


### PR DESCRIPTION
The linked repository and command output mismatched the command shown which might lead to confusion if users miss the bash tests documentation which also points to the correct bats-core install.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
