### PR TITLE
trigger a rebuild because linter failed on old pr.

### DIFF
--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -25,7 +25,7 @@ install it from your favorite package manager, on OS X with homebrew
 this would look something like this:
 
 ```
-$ brew install bats-core
+$ brew install bats-core 
 ==> Downloading
 https://github.com/bats-core/bats-core/archive/v1.2.0.tar.gz
 ==> Downloading from


### PR DESCRIPTION
the readme on the hello world exercise is recommending installing 
$ brew install bats

when it should be the supported package.
$ brew install bats-core

https://github.com/exercism/bash/pull/491/checks
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
