### PR TITLE
add new Markdown test cases

### DIFF
--- a/exercises/practice/markdown/.meta/example.sh
+++ b/exercises/practice/markdown/.meta/example.sh
@@ -48,7 +48,7 @@ main() {
 
             # Check for a heading
 
-            if [[ $line =~ ^("#"+)" "(.*) ]]; then
+            if [[ $line =~ ^("#"{1,6})" "(.*) ]]; then
                 n=${#BASH_REMATCH[1]}
                 html+=$(printf "<h%d>%s</h%d>" $n "${BASH_REMATCH[2]}" $n)
 

--- a/exercises/practice/markdown/.meta/tests.toml
+++ b/exercises/practice/markdown/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [e75c8103-a6b8-45d9-84ad-e68520545f6e]
 description = "parses normal text as a paragraph"
@@ -20,8 +27,25 @@ description = "with h1 header level"
 [d0f7a31f-6935-44ac-8a9a-1e8ab16af77f]
 description = "with h2 header level"
 
+[9df3f500-0622-4696-81a7-d5babd9b5f49]
+description = "with h3 header level"
+
+[50862777-a5e8-42e9-a3b8-4ba6fcd0ed03]
+description = "with h4 header level"
+
+[ee1c23ac-4c86-4f2a-8b9c-403548d4ab82]
+description = "with h5 header level"
+
 [13b5f410-33f5-44f0-a6a7-cfd4ab74b5d5]
 description = "with h6 header level"
+
+[6dca5d10-5c22-4e2a-ac2b-bd6f21e61939]
+description = "with h7 header level"
+include = false
+
+[81c0c4db-435e-4d77-860d-45afacdad810]
+description = "h7 header level is a paragraph"
+reimplements = "6dca5d10-5c22-4e2a-ac2b-bd6f21e61939"
 
 [25288a2b-8edc-45db-84cf-0b6c6ee034d6]
 description = "unordered lists"

--- a/exercises/practice/markdown/markdown.bats
+++ b/exercises/practice/markdown/markdown.bats
@@ -79,6 +79,36 @@ END
     assert_output "<h2>This  will be an h2</h2>"
 }
 
+@test "with h3 header level" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    cat <<END > "$MD_FILE"
+### This  will be an h3
+END
+    run bash markdown.sh "$MD_FILE"
+    assert_success
+    assert_output "<h3>This  will be an h3</h3>"
+}
+
+@test "with h4 header level" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    cat <<END > "$MD_FILE"
+#### This  will be an h4
+END
+    run bash markdown.sh "$MD_FILE"
+    assert_success
+    assert_output "<h4>This  will be an h4</h4>"
+}
+
+@test "with h5 header level" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    cat <<END > "$MD_FILE"
+##### This  will be an h5
+END
+    run bash markdown.sh "$MD_FILE"
+    assert_success
+    assert_output "<h5>This  will be an h5</h5>"
+}
+
 @test "with h6 header level" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     cat <<END > "$MD_FILE"
@@ -87,6 +117,16 @@ END
     run bash markdown.sh "$MD_FILE"
     assert_success
     assert_output "<h6>This will be an h6</h6>"
+}
+
+@test "with h7 header level" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    cat <<END > "$MD_FILE"
+####### This will not be an h7
+END
+    run bash markdown.sh "$MD_FILE"
+    assert_success
+    assert_output "<p>####### This will not be an h7</p>"
 }
 
 @test "unordered lists" {

--- a/exercises/practice/markdown/markdown.sh
+++ b/exercises/practice/markdown/markdown.sh
@@ -37,7 +37,7 @@ done
     fi
 
             n=`expr "$line" : "#\{1,\}"`
-            if [ $n -gt 0 ]; then
+            if [ $n -gt 0 -a 7 -gt $n ]; then
 
         while [[ $line == *_*?_* ]]; do
             s=${line#*_}


### PR DESCRIPTION
Checks headers for h3, h4, h5, and validates that 7 hashes don't generate a h7

Recall that this is a refactoring exercise, so the stub file must pass the test suite.  
Fix was required for example solution too.