### PR TITLE
fix: absolute path to instructions to install bats

### DIFF
--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -7,7 +7,7 @@ bats hello_world.bats
 ```
 
 `bats` will need to be installed.
-See the [Testing on the Bash track](/docs/tracks/bash/tests) page for
+See the [Testing on the Bash track](https://exercism.org/docs/tracks/bash/tests) page for
 instructions to install `bats` for your system.
 
 ## Help for assert functions


### PR DESCRIPTION
Change path to absolute path for instructions to install bats in HELP.md
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
