### PR TITLE
Remove non-project related gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 bin/configlet
 bin/configlet.exe
-
-*.swp


### PR DESCRIPTION
This removes an entry from gitignore, which is is meant to be used for
project related ignores, things that are generated by the project
itself, rather than personal choices that create artifacts.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
