### PR TITLE
Test for negative arguments

### DIFF
--- a/exercises/practice/beer-song/beer_song.bats
+++ b/exercises/practice/beer-song/beer_song.bats
@@ -405,3 +405,17 @@ Go to the store and buy some more, 99 bottles of beer on the wall."
     assert_failure
     assert_output "Start must be greater than End"
 }
+
+@test 'negative_start' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run bash beer_song.sh -1
+    assert_failure
+    assert_output "Start must be positive"
+}
+
+@test 'negative_end' {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run bash beer_song.sh 99 -1
+    assert_failure
+    assert_output "End must be positive"
+}


### PR DESCRIPTION
<!-- Your content goes here: -->
As it is, the tests don't check for either argument being negative. Negative values being allowed results in unexpected behaviors.
This patch tests for each individually, expecting an error code and message.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
