### PR TITLE
Remove reference to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Exercism Bash Track
 
 [![Build Status](https://travis-ci.org/exercism/bash.svg?branch=master)](https://travis-ci.org/exercism/bash)
-[![Gitter](https://badges.gitter.im/exercism/bash.svg)](https://gitter.im/exercism/bash?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
 Exercism Exercises in Bash
 


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.




<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
