### PR TITLE
Sync new test for crypto-square: normalization results in empty plaintext

### DIFF
--- a/exercises/practice/crypto-square/.meta/tests.toml
+++ b/exercises/practice/crypto-square/.meta/tests.toml
@@ -5,6 +5,9 @@
 [407c3837-9aa7-4111-ab63-ec54b58e8e9f]
 description = "empty plaintext results in an empty ciphertext"
 
+[aad04a25-b8bb-4304-888b-581bea8e0040]
+description = "normalization results in empty plaintext"
+
 [64131d65-6fd9-4f58-bdd8-4a2370fb481d]
 description = "Lowercase"
 

--- a/exercises/practice/crypto-square/crypto_square.bats
+++ b/exercises/practice/crypto-square/crypto_square.bats
@@ -11,6 +11,13 @@ load bats-extra
     assert_output ""
 }
 
+@test "normalization results in empty plaintext" {
+    [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    run bash crypto_square.sh "... --- ..."
+    assert_success
+    assert_output ""
+}
+
 @test "Lowercase" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash crypto_square.sh "A"


### PR DESCRIPTION
Sync new test for crypto-square: normalization results in empty plaintext



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
