### PR TITLE
Update all_your_base.bats

### DIFF
--- a/exercises/practice/all-your-base/.meta/example.sh
+++ b/exercises/practice/all-your-base/.meta/example.sh
@@ -21,6 +21,11 @@ main() {
         decimal=$(( from_base * decimal + digit ))
     done
 
+    if (( decimal == 0 )); then
+	echo 0
+	return 0
+    fi
+    
     digits=()
     while (( decimal > 0 )); do
         digit=$(( decimal % to_base ))

--- a/exercises/practice/all-your-base/all_your_base.bats
+++ b/exercises/practice/all-your-base/all_your_base.bats
@@ -70,14 +70,14 @@ load bats-extra
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash all_your_base.sh 10 "0" 2
     assert_success
-    assert_output ""
+    assert_output "0"
 }
 
 @test 'multiple zeroes' {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash all_your_base.sh 10 "0 0 0" 2
     assert_success
-    assert_output ""
+    assert_output "0"
 }
 
 @test 'leading zeros' {

--- a/exercises/practice/all-your-base/all_your_base.bats
+++ b/exercises/practice/all-your-base/all_your_base.bats
@@ -63,7 +63,7 @@ load bats-extra
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash all_your_base.sh 2 "" 10
     assert_success
-    assert_output ""
+    assert_output "0"
 }
 
 @test 'single zero' {


### PR DESCRIPTION
Zero is zero in whatever base, then the correct output for whatever list of zeros must be zero.  For example in the base 10: 0 is zero, to passing this to other base greater of 1 you need divide 0 between the number of the other base: 0 divided on other number have quotient 0 and residue 0 hence 0 from base 10 is 0 in whatever base greater of 1.

# pull request template

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
