### PR TITLE
Fix #637: pass actual newlines to the exercise script, not literal '\n' strings

### DIFF
--- a/exercises/practice/word-count/word_count.bats
+++ b/exercises/practice/word-count/word_count.bats
@@ -45,7 +45,7 @@ load bats-extra
 
 @test "handles expanded lists" {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-  run bash word_count.sh "one,\ntwo,\nthree"
+  run bash word_count.sh $'one,\ntwo,\nthree'
   assert_success
   assert_line "one: 1"
   assert_line "two: 1"


### PR DESCRIPTION
Not much to say, just run the actual test which was intended...

# pull request template

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
