### PR TITLE
CI: pin GitHub Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,7 +6,7 @@ on: pull_request
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout PR


### PR DESCRIPTION
This PR updates GitHub Actions runners to a specific version.
This ensures that the workflow will always run on the same runner, which makes your build _stable_.

The PR updates the *-latest version with the current version, as specified in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-test-runners-to-version for more information.