### PR TITLE
Add a test which fails if lexicographical sorting was used

### DIFF
--- a/exercises/practice/triangle/triangle.bats
+++ b/exercises/practice/triangle/triangle.bats
@@ -153,7 +153,7 @@ load bats-extra
   assert_output "false"
 }
 
-@test "test not against lexicographical sorting" {
+@test "test against lexicographical sorting" {
   [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash triangle.sh scalene 10 3 2
   assert_success

--- a/exercises/practice/triangle/triangle.bats
+++ b/exercises/practice/triangle/triangle.bats
@@ -153,6 +153,13 @@ load bats-extra
   assert_output "false"
 }
 
+@test "test not against lexicographical sorting" {
+  [[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash triangle.sh scalene 10 3 2
+  assert_success
+  assert_output "false"
+}
+
 # Bonus: deal with floats
 
 @test "sides may be floats, scalene" {


### PR DESCRIPTION
Add test verifying that the sorting happened in a numerical fashion and not lexicographical.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
