### PR TITLE
test: update Darts exercise test case

### DIFF
--- a/exercises/practice/darts/darts.bats
+++ b/exercises/practice/darts/darts.bats
@@ -119,7 +119,7 @@ load bats-extra
 
 @test "invalid args: second arg non-numeric" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    run bash darts.sh 10 bar
+    run bash darts.sh 10 bar5
     assert_failure
     assert_output    # there is _some_ output
 }


### PR DESCRIPTION
I was able to pass this exercise using incorrect `[[:digit:]]` regular expression that only checked that an argument includes a number so I've decided to slightly update the test case for a non-numeric argument.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
