### PR TITLE
Add debugging output section to TESTS.md and adjust formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Exercism Exercises in Bash
 
+If you are solving exercises locally and need help with Bats debug output, see [docs/DEBUGGING_LOCALLY.md](docs/DEBUGGING_LOCALLY.md).
+
 ## Contributing Guide
 
 Please see the [contributing guide](https://github.com/exercism/bash/blob/master/CONTRIBUTING.md) for information.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Exercism Exercises in Bash
 
-If you are solving exercises locally and need help with Bats debug output, see [docs/DEBUGGING_LOCALLY.md](docs/DEBUGGING_LOCALLY.md).
+If you are solving exercises locally and need help with Bats debug output, see [Debugging with `bats`](https://exercism.org/docs/tracks/bash/debugging).
 
 ## Contributing Guide
 

--- a/docs/DEBUGGING_LOCALLY.md
+++ b/docs/DEBUGGING_LOCALLY.md
@@ -1,0 +1,27 @@
+# Debugging Locally
+
+When you run Bash track tests with [Bats](https://github.com/bats-core/bats-core), Bats captures both stdout and stderr for output assertions.
+
+```exercism/caution
+This works locally with `bats`, but **not** in the Exercism online editor.
+```
+
+If you want to print debug output without affecting the test result, write it to file descriptor 3:
+
+```bash
+echo 'debug message' >&3
+```
+
+Bats shows output written to fd 3 during the test run, but it does not include that output in assertions such as `assert_output`.
+
+Example run:
+
+```none
+$ bats hello_world.bats
+hello_world.bats
+ ✓ Say Hi!
+debug message
+1 test, 0 failures
+```
+
+This is useful when you are running the tests locally. The Exercism online editor does not support this pattern.

--- a/docs/DEBUGGING_LOCALLY.md
+++ b/docs/DEBUGGING_LOCALLY.md
@@ -1,12 +1,12 @@
 # Debugging Locally
 
-When you run Bash track tests with [Bats](https://github.com/bats-core/bats-core), Bats captures both stdout and stderr for output assertions.
+When you run Bash track tests with [Bats](https://github.com/bats-core/bats-core), Bats captures both STDOUT and STDERR for output assertions.
 
 ```exercism/caution
 This works locally with `bats`, but **not** in the Exercism online editor.
 ```
 
-If you want to print debug output without affecting the test result, write it to file descriptor 3.
+If you want to print debug output without affecting the test result, write it to file descriptor (fd) 3.
 
 ```bash
 echo 'debug message' >&3
@@ -25,4 +25,3 @@ debug message
 ```
 
 This is useful when you are running the tests locally.
-The Exercism online editor does not support this pattern.

--- a/docs/DEBUGGING_LOCALLY.md
+++ b/docs/DEBUGGING_LOCALLY.md
@@ -6,7 +6,7 @@ When you run Bash track tests with [Bats](https://github.com/bats-core/bats-core
 This works locally with `bats`, but **not** in the Exercism online editor.
 ```
 
-If you want to print debug output without affecting the test result, write it to file descriptor 3:
+If you want to print debug output without affecting the test result, write it to file descriptor 3.
 
 ```bash
 echo 'debug message' >&3
@@ -24,4 +24,5 @@ debug message
 1 test, 0 failures
 ```
 
-This is useful when you are running the tests locally. The Exercism online editor does not support this pattern.
+This is useful when you are running the tests locally.
+The Exercism online editor does not support this pattern.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -39,6 +39,8 @@ cd /path/to/your/exercise_workspace/bash/whatever
 bats whatever.bats
 ```
 
+If you want to print debug output while running the tests locally, see [Debugging Locally](DEBUGGING_LOCALLY.md).
+
 ## Installing `bats-core`
 
 You should be able to install it from your favorite package manager:
@@ -110,26 +112,6 @@ $ git checkout v1.1.0
 ## bats-assert
 
 For help on the meaning of the various `assert*` commands in the tests, refer to the documentation for the [bats-assert][bats-assert] library.
-
-## Debugging output
-
-When running tests, `bats` captures both stdout and stderr for output assertions.
-This means debug output printed with `echo` (stdout) or redirected to `>&2` (stderr) can cause tests to fail.
-
-For debugging, print to file descriptor `3` instead.
-`bats` reserves fd 3 for diagnostic output that is shown during test runs but not included in captured output.
-
-Example:
-
-```bash
-#!/usr/bin/env bash
-
-printf '%(%T)T -- %s\n' -1 'a debugging statement' >&3
-echo "Hello, World!"
-```
-
-Use this only when testing locally.
-The Exercism online editor does not support this style of debug output.
 
 ## Skipped tests
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -56,8 +56,8 @@ $ brew install bats-core
 🍺  /usr/local/Cellar/bats-core/1.1.0: 13 files, 55KB, built in 4 seconds
 ```
 
-* The legacy `bats` package also exists in the homebrew ecosystem.
-    **_Do not install that by mistake_**: <u>install `bats-core`</u>.
+- The legacy `bats` package also exists in the homebrew ecosystem.
+  **_Do not install that by mistake_**: <u>install `bats-core`</u>.
 
 ### For Linux
 
@@ -111,6 +111,26 @@ $ git checkout v1.1.0
 
 For help on the meaning of the various `assert*` commands in the tests, refer to the documentation for the [bats-assert][bats-assert] library.
 
+## Debugging output
+
+When running tests, `bats` captures both stdout and stderr for output assertions.
+This means debug output printed with `echo` (stdout) or redirected to `>&2` (stderr) can cause tests to fail.
+
+For debugging, print to file descriptor `3` instead.
+`bats` reserves fd 3 for diagnostic output that is shown during test runs but not included in captured output.
+
+Example:
+
+```bash
+#!/usr/bin/env bash
+
+printf '%(%T)T -- %s\n' -1 'a debugging statement' >&3
+echo "Hello, World!"
+```
+
+Use this only when testing locally.
+The Exercism online editor does not support this style of debug output.
+
 ## Skipped tests
 
 Solving an exercise means making all its tests pass.
@@ -124,7 +144,7 @@ annotations prepending other tests.
 
 ### Overriding skips
 
-To run all tests, including the ones with `skip` annotations, you can set an environment variable `BATS_RUN_SKIPPED` to the value `true`. 
+To run all tests, including the ones with `skip` annotations, you can set an environment variable `BATS_RUN_SKIPPED` to the value `true`.
 One way to set this just for the duration of running bats is:
 
 ```bash
@@ -152,7 +172,6 @@ The `sstephenson/bats` project was quite buggy and had been abandoned.
 Ownership was handed over in 2017: [sstephenson/bats#150 (comment)][bats-fork].
 
 If you have the original sstephenson/bats installed (check with `bats -v` reporting a version number less than 1.0), then you should switch to bats-core; otherwise you may find yourself [experiencing unexplained test failures][legacy-failures].
-
 
 [exercism-cli]: https://exercism.org/docs/using/solving-exercises/working-locally
 [bats]: https://github.com/bats-core/bats-core

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -39,7 +39,7 @@ cd /path/to/your/exercise_workspace/bash/whatever
 bats whatever.bats
 ```
 
-If you want to print debug output while running the tests locally, see [Debugging Locally](DEBUGGING_LOCALLY.md).
+If you want to print debug output while running the tests locally, see [Debugging Locally](/docs/tracks/bash/debugging).
 
 ## Installing `bats-core`
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -22,6 +22,13 @@
       "blurb": "Learn how to test your Bash exercises on Exercism"
     },
     {
+      "uuid": "14a9f11d-ada7-4f5f-a9f5-2094b3e2e659",
+      "slug": "debugging",
+      "path": "docs/DEBUGGING_LOCALLY.md",
+      "title": "Debugging with `bats`",
+      "blurb": "Debugging your Bash code while testing with bats."
+    },
+    {
       "uuid": "c74e1d25-18f1-4212-a10c-05303a962b1c",
       "slug": "resources",
       "path": "docs/RESOURCES.md",

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -7,12 +7,13 @@ Run the tests using the `bats` program.
 bats hello_world.bats
 ```
 
-If you need to print debug output while running tests locally, see [Debugging Locally](https://exercism.org/docs/tracks/bash/debugging).
+If you need to print debug output while running tests locally, see [Debugging Locally][debugging].
 
 `bats` will need to be installed.
 See the [Testing on the Bash track][tests] page for instructions to install `bats` for your system.
 
 [tests]: https://exercism.org/docs/tracks/bash/tests
+[debugging]: https://exercism.org/docs/tracks/bash/debugging
 
 ## Help for assert functions
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -7,6 +7,8 @@ Run the tests using the `bats` program.
 bats hello_world.bats
 ```
 
+If you need to print debug output while running tests locally, see [Debugging Locally](https://github.com/exercism/bash/blob/master/docs/DEBUGGING_LOCALLY.md).
+
 `bats` will need to be installed.
 See the [Testing on the Bash track][tests] page for instructions to install `bats` for your system.
 
@@ -18,42 +20,6 @@ The tests use functions from the [bats-assert][bats-assert] library.
 Help for the various `assert*` functions can be found there.
 
 [bats-assert]: https://github.com/bats-core/bats-assert
-
-## Debugging output
-
-```exercism/caution
-This works locally with `bats`, but **not** in the Exercism online editor.
-```
-
-When running tests, `bats` captures both stdout and stderr for comparison with the expected output.
-If you print debug messages to stdout (`echo`) or stderr (`>&2`), they will be included in the captured output and may cause the test to fail.
-
-To print debug information without affecting the test results, `bats` provides file descriptor **3** for this purpose.
-Anything redirected to `>&3` will be shown during the test run but will not be included in the captured output used for assertions.
-
-Example:
-
-```bash
-#!/usr/bin/env bash
-
-# This debug message will not interfere with test output comparison
-echo "debug message" >&3
-
-# Normal program output (this is what your tests will see and compare)
-echo "Hello, World!"
-```
-
-Example run:
-
-```none
-$ bats hello_world.bats
-hello_world.bats
- ✓ Say Hi!
-debug message
-1 test, 0 failures
-```
-
-This allows you to see helpful debug output without affecting the tests.
 
 ## Skipped tests
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -7,7 +7,7 @@ Run the tests using the `bats` program.
 bats hello_world.bats
 ```
 
-If you need to print debug output while running tests locally, see [Debugging Locally](https://github.com/exercism/bash/blob/master/docs/DEBUGGING_LOCALLY.md).
+If you need to print debug output while running tests locally, see [Debugging Locally](https://exercism.org/docs/tracks/bash/debugging).
 
 `bats` will need to be installed.
 See the [Testing on the Bash track][tests] page for instructions to install `bats` for your system.


### PR DESCRIPTION
# pull request template


### Summary
Closes #744.

This PR documents how to print debug output while running Bash track tests with Bats without breaking output assertions.

### What Changed
- Added a Debugging output section to `docs/TESTS.md`.
- Clarified that Bats captures both stdout and stderr for assertions.
- Documented using file descriptor 3 (`>&3`) for debug messages so they are visible during local runs but excluded from asserted output.
- Added note that this debugging approach is for local testing, not the Exercism online editor.

### Why
Students may print debug text to stderr and see unexpected test failures. This update explains the expected behavior and recommended workflow clearly.

### Testing
- Docs-only change.
- Content reviewed for clarity and consistency with existing track guidance.


---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
