### PR TITLE
Align instruction exemples with `assert_output` expected in `secret handshake` exercice

### DIFF
--- a/exercises/practice/secret-handshake/.docs/instructions.md
+++ b/exercises/practice/secret-handshake/.docs/instructions.md
@@ -26,7 +26,7 @@ Let's use the number `9` as an example:
 That was the last digit, so the final code is:
 
 ```plaintext
-wink, jump
+wink,jump
 ```
 
 Given the number 26, which is `11010` in binary, we get the following actions:
@@ -38,7 +38,7 @@ Given the number 26, which is `11010` in binary, we get the following actions:
 The secret handshake for 26 is therefore:
 
 ```plaintext
-jump, double blink
+jump,double blink
 ```
 
 ~~~~exercism/note


### PR DESCRIPTION
In this exercice, there's a difference between the output expected (`wink,double blink`) and the exemples given in the `instructions.md` file (`wink, jump`) -> **extra space after comma**.

This PR is to align them.

I choose to edit the `instructions.md` file so the tests have not to be run again.

If the intent was that the outputs should have that extra space after comma, the `secret_handshake.bats` file needs to be modified but in that case, all the tests must be run again as the `assert_output` would no longer be the same.


[no important files changed]
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/bash/blob/master/POLICIES.md)
