### PR TITLE
Shellcheck part 1: bin scripts and non-example exercise files

### DIFF
--- a/exercises/practice/acronym/bats-extra.bash
+++ b/exercises/practice/acronym/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/acronym/bats-extra.bash
+++ b/exercises/practice/acronym/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/affine-cipher/bats-extra.bash
+++ b/exercises/practice/affine-cipher/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/affine-cipher/bats-extra.bash
+++ b/exercises/practice/affine-cipher/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/all-your-base/bats-extra.bash
+++ b/exercises/practice/all-your-base/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/all-your-base/bats-extra.bash
+++ b/exercises/practice/all-your-base/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/allergies/bats-extra.bash
+++ b/exercises/practice/allergies/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/allergies/bats-extra.bash
+++ b/exercises/practice/allergies/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/anagram/bats-extra.bash
+++ b/exercises/practice/anagram/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/anagram/bats-extra.bash
+++ b/exercises/practice/anagram/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/armstrong-numbers/bats-extra.bash
+++ b/exercises/practice/armstrong-numbers/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/armstrong-numbers/bats-extra.bash
+++ b/exercises/practice/armstrong-numbers/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/atbash-cipher/bats-extra.bash
+++ b/exercises/practice/atbash-cipher/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/atbash-cipher/bats-extra.bash
+++ b/exercises/practice/atbash-cipher/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/beer-song/bats-extra.bash
+++ b/exercises/practice/beer-song/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/beer-song/bats-extra.bash
+++ b/exercises/practice/beer-song/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/binary-search/bats-extra.bash
+++ b/exercises/practice/binary-search/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/binary-search/bats-extra.bash
+++ b/exercises/practice/binary-search/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/bob/bats-extra.bash
+++ b/exercises/practice/bob/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/bob/bats-extra.bash
+++ b/exercises/practice/bob/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/bottle-song/bats-extra.bash
+++ b/exercises/practice/bottle-song/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/bottle-song/bats-extra.bash
+++ b/exercises/practice/bottle-song/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/bowling/bats-extra.bash
+++ b/exercises/practice/bowling/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/bowling/bats-extra.bash
+++ b/exercises/practice/bowling/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/change/bats-extra.bash
+++ b/exercises/practice/change/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/change/bats-extra.bash
+++ b/exercises/practice/change/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/clock/bats-extra.bash
+++ b/exercises/practice/clock/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/clock/bats-extra.bash
+++ b/exercises/practice/clock/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/collatz-conjecture/bats-extra.bash
+++ b/exercises/practice/collatz-conjecture/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/collatz-conjecture/bats-extra.bash
+++ b/exercises/practice/collatz-conjecture/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/crypto-square/bats-extra.bash
+++ b/exercises/practice/crypto-square/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/crypto-square/bats-extra.bash
+++ b/exercises/practice/crypto-square/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/darts/bats-extra.bash
+++ b/exercises/practice/darts/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/darts/bats-extra.bash
+++ b/exercises/practice/darts/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/diamond/bats-extra.bash
+++ b/exercises/practice/diamond/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/diamond/bats-extra.bash
+++ b/exercises/practice/diamond/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/difference-of-squares/bats-extra.bash
+++ b/exercises/practice/difference-of-squares/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/difference-of-squares/bats-extra.bash
+++ b/exercises/practice/difference-of-squares/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/diffie-hellman/bats-extra.bash
+++ b/exercises/practice/diffie-hellman/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/diffie-hellman/bats-extra.bash
+++ b/exercises/practice/diffie-hellman/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/dnd-character/bats-extra.bash
+++ b/exercises/practice/dnd-character/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/dnd-character/bats-extra.bash
+++ b/exercises/practice/dnd-character/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/dnd-character/dnd_character.bats
+++ b/exercises/practice/dnd-character/dnd_character.bats
@@ -153,8 +153,8 @@ between() {
 # random ability is within range
 @test "validate ability range and hitpoint value" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    for i in {1..50}; do
-        while read c v; do
+    for _ in {1..50}; do
+        while read -r c v; do
             if [[ $c == "hitpoints" ]]; then
                 hits=$v
             else

--- a/exercises/practice/eliuds-eggs/bats-extra.bash
+++ b/exercises/practice/eliuds-eggs/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/eliuds-eggs/bats-extra.bash
+++ b/exercises/practice/eliuds-eggs/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/error-handling/bats-extra.bash
+++ b/exercises/practice/error-handling/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/error-handling/bats-extra.bash
+++ b/exercises/practice/error-handling/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/flower-field/bats-extra.bash
+++ b/exercises/practice/flower-field/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/flower-field/bats-extra.bash
+++ b/exercises/practice/flower-field/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/food-chain/bats-extra.bash
+++ b/exercises/practice/food-chain/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/food-chain/bats-extra.bash
+++ b/exercises/practice/food-chain/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/forth/bats-extra.bash
+++ b/exercises/practice/forth/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/forth/bats-extra.bash
+++ b/exercises/practice/forth/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/gigasecond/bats-extra.bash
+++ b/exercises/practice/gigasecond/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/gigasecond/bats-extra.bash
+++ b/exercises/practice/gigasecond/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/grains/bats-extra.bash
+++ b/exercises/practice/grains/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/grains/bats-extra.bash
+++ b/exercises/practice/grains/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/grep/bats-extra.bash
+++ b/exercises/practice/grep/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/grep/bats-extra.bash
+++ b/exercises/practice/grep/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/hamming/bats-extra.bash
+++ b/exercises/practice/hamming/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/hamming/bats-extra.bash
+++ b/exercises/practice/hamming/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/hello-world/bats-extra.bash
+++ b/exercises/practice/hello-world/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/hello-world/bats-extra.bash
+++ b/exercises/practice/hello-world/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/house/bats-extra.bash
+++ b/exercises/practice/house/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/house/bats-extra.bash
+++ b/exercises/practice/house/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/isbn-verifier/bats-extra.bash
+++ b/exercises/practice/isbn-verifier/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/isbn-verifier/bats-extra.bash
+++ b/exercises/practice/isbn-verifier/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/isogram/bats-extra.bash
+++ b/exercises/practice/isogram/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/isogram/bats-extra.bash
+++ b/exercises/practice/isogram/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/kindergarten-garden/bats-extra.bash
+++ b/exercises/practice/kindergarten-garden/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/kindergarten-garden/bats-extra.bash
+++ b/exercises/practice/kindergarten-garden/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/knapsack/bats-extra.bash
+++ b/exercises/practice/knapsack/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/knapsack/bats-extra.bash
+++ b/exercises/practice/knapsack/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/largest-series-product/bats-extra.bash
+++ b/exercises/practice/largest-series-product/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/largest-series-product/bats-extra.bash
+++ b/exercises/practice/largest-series-product/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/leap/bats-extra.bash
+++ b/exercises/practice/leap/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/leap/bats-extra.bash
+++ b/exercises/practice/leap/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/line-up/bats-extra.bash
+++ b/exercises/practice/line-up/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/line-up/bats-extra.bash
+++ b/exercises/practice/line-up/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/list-ops/bats-extra.bash
+++ b/exercises/practice/list-ops/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/list-ops/bats-extra.bash
+++ b/exercises/practice/list-ops/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/list-ops/list_ops.bats
+++ b/exercises/practice/list-ops/list_ops.bats
@@ -1,4 +1,6 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2329 # "This function is never invoked."
+
 load bats-extra
 
 # local version: 2.4.0.0
@@ -15,8 +17,8 @@ setup() { source list_ops.sh; }
 
 @test "append empty lists" {
     #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list1=()
-    list2=()
+    local list1=()
+    local list2=()
     list::append list1 "${list2[@]}"
     assert_equal "${#list1[@]}" 0
     assert_equal "${list1[*]}" ""
@@ -24,8 +26,8 @@ setup() { source list_ops.sh; }
 
 @test "append list to empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list1=()
-    list2=(1 2 3 4)
+    local list1=()
+    local list2=(1 2 3 4)
     list::append list1 "${list2[@]}"
     assert_equal "${#list1[@]}" 4
     assert_equal "${list1[*]}" "1 2 3 4"
@@ -33,8 +35,8 @@ setup() { source list_ops.sh; }
 
 @test "append empty list to list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list1=(1 2 3 4)
-    list2=()
+    local list1=(1 2 3 4)
+    local list2=()
     list::append list1 "${list2[@]}"
     assert_equal "${#list1[@]}" 4
     assert_equal "${list1[*]}" "1 2 3 4"
@@ -42,8 +44,8 @@ setup() { source list_ops.sh; }
 
 @test "append non-empty lists" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    l1=(1 2)
-    l2=(2 3 4 5)
+    local l1=(1 2)
+    local l2=(2 3 4 5)
     list::append l1 "${l2[@]}"
     assert_equal "${#l1[@]}" 6
     assert_equal "${l1[*]}" "1 2 2 3 4 5"
@@ -56,8 +58,8 @@ setup() { source list_ops.sh; }
 
 @test "filter empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=()
-    result=()
+    local list=()
+    local result=()
     isOdd () { (( $1 % 2 == 1 )); }
     list::filter isOdd list result
     assert_equal "${#result[@]}" 0
@@ -66,8 +68,8 @@ setup() { source list_ops.sh; }
 
 @test "filter non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 2 3 4 5)
-    result=()
+    local list=(1 2 3 4 5)
+    local result=()
     isOdd () { (( $1 % 2 == 1 )); }
     list::filter isOdd list result
     assert_equal "${#result[@]}" 3
@@ -82,8 +84,8 @@ setup() { source list_ops.sh; }
 
 @test "map empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=()
-    result=()
+    local list=()
+    local result=()
     incr () { echo $(( $1 + 1 )); }
     list::map incr list result
     assert_equal "${#result[@]}" ${#list[@]}
@@ -92,8 +94,8 @@ setup() { source list_ops.sh; }
 
 @test "map non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 3 5 7)
-    result=()
+    local list=(1 3 5 7)
+    local result=()
     incr () { echo $(( $1 + 1 )); }
     list::map incr list result
     assert_equal "${#result[@]}" ${#list[@]}
@@ -104,7 +106,8 @@ setup() { source list_ops.sh; }
 
 @test "foldl empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=()
+    local list=()
+    local result
     mult () {
         local acc=$1 elem=$2
         echo $(( elem * acc ))
@@ -115,7 +118,8 @@ setup() { source list_ops.sh; }
 
 @test "foldl direction independent function applied to non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 2 3 4)
+    local list=(1 2 3 4)
+    local result
     add () {
         local acc=$1 elem=$2
         echo $(( elem + acc ))
@@ -126,7 +130,8 @@ setup() { source list_ops.sh; }
 
 @test "foldl direction dependent function applied to non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 2 3 4)
+    local list=(1 2 3 4)
+    local result answer
     # For this test, we need a div function that performs
     # floating point arithmetic to preserve fractions.
     div () {
@@ -141,7 +146,8 @@ setup() { source list_ops.sh; }
 # track-specific test
 @test "foldl not just numbers" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(H e l l o " " W o r l d "!")
+    local list=(H e l l o " " W o r l d "!")
+    local result
     concat () {
         local acc=$1 elem=$2
         echo "${acc}${elem}"
@@ -155,7 +161,8 @@ setup() { source list_ops.sh; }
 
 @test "foldr empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=()
+    local list=()
+    local result
     mult () {
         local elem=$1 acc=$2
         echo $(( elem * acc ))
@@ -166,7 +173,8 @@ setup() { source list_ops.sh; }
 
 @test "foldr direction independent function applied to non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 2 3 4)
+    local list=(1 2 3 4)
+    local result
     add () {
         local elem=$1 acc=$2
         echo $(( elem + acc ))
@@ -177,7 +185,8 @@ setup() { source list_ops.sh; }
 
 @test "foldr direction dependent function applied to non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 2 3 4)
+    local list=(1 2 3 4)
+    local answer result
     div () {
         local elem=$1 acc=$2
         echo "$elem / $acc" | bc -l
@@ -190,7 +199,8 @@ setup() { source list_ops.sh; }
 # track-specific test
 @test "foldr not just numbers" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(H e l l o " " W o r l d "!")
+    local list=(H e l l o " " W o r l d "!")
+    local result
     concat () {
         local elem=$1 acc=$2
         echo "${acc}${elem}"
@@ -203,8 +213,8 @@ setup() { source list_ops.sh; }
 
 @test "reverse empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=()
-    result=()
+    local list=()
+    local result=()
     list::reverse list result
     assert_equal "${#result[@]}" ${#list[@]}
     assert_equal "${result[*]}" ""
@@ -212,8 +222,8 @@ setup() { source list_ops.sh; }
 
 @test "reverse non-empty list" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=(1 3 5 7)
-    result=()
+    local list=(1 3 5 7)
+    local result=()
     list::reverse list result
     assert_equal "${#result[@]}" ${#list[@]}
     assert_equal "${result[*]}" "7 5 3 1"
@@ -221,8 +231,8 @@ setup() { source list_ops.sh; }
 
 @test "reverse with special characters" {
     [[ $BATS_RUN_SKIPPED == "true" ]] || skip
-    list=("R*" "l*")
-    result=()
+    local list=("R*" "l*")
+    local result=()
     list::reverse list result
     assert_equal "${#result[@]}" ${#list[@]}
     assert_equal "${result[*]}" "l* R*"

--- a/exercises/practice/luhn/bats-extra.bash
+++ b/exercises/practice/luhn/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/luhn/bats-extra.bash
+++ b/exercises/practice/luhn/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/markdown/bats-extra.bash
+++ b/exercises/practice/markdown/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/markdown/bats-extra.bash
+++ b/exercises/practice/markdown/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/markdown/markdown.bats
+++ b/exercises/practice/markdown/markdown.bats
@@ -5,7 +5,7 @@ load bats-extra
 
 # uses external tool: mktemp
 
-setup()    { export MD_FILE=$( mktemp ); }
+setup()    { export MD_FILE; MD_FILE=$( mktemp ); }
 teardown() { rm -f "$MD_FILE"; }
 
 

--- a/exercises/practice/matching-brackets/bats-extra.bash
+++ b/exercises/practice/matching-brackets/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/matching-brackets/bats-extra.bash
+++ b/exercises/practice/matching-brackets/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/meetup/bats-extra.bash
+++ b/exercises/practice/meetup/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/meetup/bats-extra.bash
+++ b/exercises/practice/meetup/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/minesweeper/bats-extra.bash
+++ b/exercises/practice/minesweeper/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/minesweeper/bats-extra.bash
+++ b/exercises/practice/minesweeper/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/nth-prime/bats-extra.bash
+++ b/exercises/practice/nth-prime/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/nth-prime/bats-extra.bash
+++ b/exercises/practice/nth-prime/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/nucleotide-count/bats-extra.bash
+++ b/exercises/practice/nucleotide-count/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/nucleotide-count/bats-extra.bash
+++ b/exercises/practice/nucleotide-count/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/ocr-numbers/bats-extra.bash
+++ b/exercises/practice/ocr-numbers/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/ocr-numbers/bats-extra.bash
+++ b/exercises/practice/ocr-numbers/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/palindrome-products/.meta/example2.sh
+++ b/exercises/practice/palindrome-products/.meta/example2.sh
@@ -29,7 +29,7 @@ main() {
         for ((j = i; j <= max; j++)); do
             prod=$(( i * j ))
             if is_palindrome "$prod"; then
-                palindromes[$prod]+=" [$i, $j]"
+                palindromes[prod]+=" [$i, $j]"
             fi
         done
     done

--- a/exercises/practice/palindrome-products/bats-extra.bash
+++ b/exercises/practice/palindrome-products/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/palindrome-products/bats-extra.bash
+++ b/exercises/practice/palindrome-products/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/pangram/bats-extra.bash
+++ b/exercises/practice/pangram/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/pangram/bats-extra.bash
+++ b/exercises/practice/pangram/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/pascals-triangle/.meta/example2.sh
+++ b/exercises/practice/pascals-triangle/.meta/example2.sh
@@ -21,7 +21,6 @@ declare -i maxFactCached=1
 
 main() {
     local -i n=$1 i
-    local spaces
     for (( i = 1; i <= n; i++ )); do
         # print the leading spaces for this row
         printf "%*s" $((n - i)) ""
@@ -37,7 +36,7 @@ row() {
         _n=$(( n - 1 ))
         _k=$(( k - 1 ))
         binomialCoefficient $_n $_k
-        row+=( ${bcCache[$_n,$_k]} )
+        row+=( "${bcCache[$_n,$_k]}" )
     done
     echo "${row[*]}"
 }

--- a/exercises/practice/pascals-triangle/bats-extra.bash
+++ b/exercises/practice/pascals-triangle/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/pascals-triangle/bats-extra.bash
+++ b/exercises/practice/pascals-triangle/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/perfect-numbers/bats-extra.bash
+++ b/exercises/practice/perfect-numbers/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/perfect-numbers/bats-extra.bash
+++ b/exercises/practice/perfect-numbers/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/phone-number/bats-extra.bash
+++ b/exercises/practice/phone-number/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/phone-number/bats-extra.bash
+++ b/exercises/practice/phone-number/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/pig-latin/bats-extra.bash
+++ b/exercises/practice/pig-latin/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/pig-latin/bats-extra.bash
+++ b/exercises/practice/pig-latin/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/poker/bats-extra.bash
+++ b/exercises/practice/poker/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/poker/bats-extra.bash
+++ b/exercises/practice/poker/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/prime-factors/bats-extra.bash
+++ b/exercises/practice/prime-factors/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/prime-factors/bats-extra.bash
+++ b/exercises/practice/prime-factors/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/protein-translation/bats-extra.bash
+++ b/exercises/practice/protein-translation/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/protein-translation/bats-extra.bash
+++ b/exercises/practice/protein-translation/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/proverb/bats-extra.bash
+++ b/exercises/practice/proverb/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/proverb/bats-extra.bash
+++ b/exercises/practice/proverb/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/pythagorean-triplet/bats-extra.bash
+++ b/exercises/practice/pythagorean-triplet/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/pythagorean-triplet/bats-extra.bash
+++ b/exercises/practice/pythagorean-triplet/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/queen-attack/bats-extra.bash
+++ b/exercises/practice/queen-attack/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/queen-attack/bats-extra.bash
+++ b/exercises/practice/queen-attack/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/rail-fence-cipher/bats-extra.bash
+++ b/exercises/practice/rail-fence-cipher/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/rail-fence-cipher/bats-extra.bash
+++ b/exercises/practice/rail-fence-cipher/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/raindrops/bats-extra.bash
+++ b/exercises/practice/raindrops/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/raindrops/bats-extra.bash
+++ b/exercises/practice/raindrops/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/rational-numbers/bats-extra.bash
+++ b/exercises/practice/rational-numbers/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/rational-numbers/bats-extra.bash
+++ b/exercises/practice/rational-numbers/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/rectangles/bats-extra.bash
+++ b/exercises/practice/rectangles/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/rectangles/bats-extra.bash
+++ b/exercises/practice/rectangles/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/resistor-color-duo/bats-extra.bash
+++ b/exercises/practice/resistor-color-duo/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/resistor-color-duo/bats-extra.bash
+++ b/exercises/practice/resistor-color-duo/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/resistor-color-trio/bats-extra.bash
+++ b/exercises/practice/resistor-color-trio/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/resistor-color-trio/bats-extra.bash
+++ b/exercises/practice/resistor-color-trio/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/resistor-color/bats-extra.bash
+++ b/exercises/practice/resistor-color/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/resistor-color/bats-extra.bash
+++ b/exercises/practice/resistor-color/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/reverse-string/bats-extra.bash
+++ b/exercises/practice/reverse-string/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/reverse-string/bats-extra.bash
+++ b/exercises/practice/reverse-string/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/rna-transcription/bats-extra.bash
+++ b/exercises/practice/rna-transcription/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/rna-transcription/bats-extra.bash
+++ b/exercises/practice/rna-transcription/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/robot-simulator/bats-extra.bash
+++ b/exercises/practice/robot-simulator/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/robot-simulator/bats-extra.bash
+++ b/exercises/practice/robot-simulator/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/roman-numerals/bats-extra.bash
+++ b/exercises/practice/roman-numerals/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/roman-numerals/bats-extra.bash
+++ b/exercises/practice/roman-numerals/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/rotational-cipher/bats-extra.bash
+++ b/exercises/practice/rotational-cipher/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/rotational-cipher/bats-extra.bash
+++ b/exercises/practice/rotational-cipher/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/run-length-encoding/bats-extra.bash
+++ b/exercises/practice/run-length-encoding/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/run-length-encoding/bats-extra.bash
+++ b/exercises/practice/run-length-encoding/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/satellite/bats-extra.bash
+++ b/exercises/practice/satellite/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/satellite/bats-extra.bash
+++ b/exercises/practice/satellite/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/say/bats-extra.bash
+++ b/exercises/practice/say/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/say/bats-extra.bash
+++ b/exercises/practice/say/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/scrabble-score/bats-extra.bash
+++ b/exercises/practice/scrabble-score/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/scrabble-score/bats-extra.bash
+++ b/exercises/practice/scrabble-score/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/secret-handshake/bats-extra.bash
+++ b/exercises/practice/secret-handshake/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/secret-handshake/bats-extra.bash
+++ b/exercises/practice/secret-handshake/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/series/bats-extra.bash
+++ b/exercises/practice/series/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/series/bats-extra.bash
+++ b/exercises/practice/series/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/sieve/bats-extra.bash
+++ b/exercises/practice/sieve/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/sieve/bats-extra.bash
+++ b/exercises/practice/sieve/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/simple-cipher/bats-extra.bash
+++ b/exercises/practice/simple-cipher/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/simple-cipher/bats-extra.bash
+++ b/exercises/practice/simple-cipher/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/space-age/bats-extra.bash
+++ b/exercises/practice/space-age/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/space-age/bats-extra.bash
+++ b/exercises/practice/space-age/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/spiral-matrix/bats-extra.bash
+++ b/exercises/practice/spiral-matrix/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/spiral-matrix/bats-extra.bash
+++ b/exercises/practice/spiral-matrix/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/square-root/bats-extra.bash
+++ b/exercises/practice/square-root/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/square-root/bats-extra.bash
+++ b/exercises/practice/square-root/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/sublist/bats-extra.bash
+++ b/exercises/practice/sublist/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/sublist/bats-extra.bash
+++ b/exercises/practice/sublist/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/sum-of-multiples/bats-extra.bash
+++ b/exercises/practice/sum-of-multiples/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/sum-of-multiples/bats-extra.bash
+++ b/exercises/practice/sum-of-multiples/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/swift-scheduling/bats-extra.bash
+++ b/exercises/practice/swift-scheduling/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/swift-scheduling/bats-extra.bash
+++ b/exercises/practice/swift-scheduling/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/tournament/bats-extra.bash
+++ b/exercises/practice/tournament/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/tournament/bats-extra.bash
+++ b/exercises/practice/tournament/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/transpose/bats-extra.bash
+++ b/exercises/practice/transpose/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/transpose/bats-extra.bash
+++ b/exercises/practice/transpose/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/triangle/bats-extra.bash
+++ b/exercises/practice/triangle/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/triangle/bats-extra.bash
+++ b/exercises/practice/triangle/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/twelve-days/bats-extra.bash
+++ b/exercises/practice/twelve-days/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/twelve-days/bats-extra.bash
+++ b/exercises/practice/twelve-days/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/two-bucket/bats-extra.bash
+++ b/exercises/practice/two-bucket/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/two-bucket/bats-extra.bash
+++ b/exercises/practice/two-bucket/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/two-fer/bats-extra.bash
+++ b/exercises/practice/two-fer/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/two-fer/bats-extra.bash
+++ b/exercises/practice/two-fer/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/variable-length-quantity/bats-extra.bash
+++ b/exercises/practice/variable-length-quantity/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/variable-length-quantity/bats-extra.bash
+++ b/exercises/practice/variable-length-quantity/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/word-count/bats-extra.bash
+++ b/exercises/practice/word-count/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/word-count/bats-extra.bash
+++ b/exercises/practice/word-count/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/wordy/bats-extra.bash
+++ b/exercises/practice/wordy/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/wordy/bats-extra.bash
+++ b/exercises/practice/wordy/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail

--- a/exercises/practice/yacht/bats-extra.bash
+++ b/exercises/practice/yacht/bats-extra.bash
@@ -20,7 +20,9 @@
 # <http://creativecommons.org/publicdomain/zero/1.0/>.
 #
 
+# shellcheck disable=SC2120 # (warning): fail references arguments, but none are ever passed.
 fail() {
+  # shellcheck disable=2015 # (info): Note that A && B || C is not if-then-else. C may run when A is true.
   (( $# == 0 )) && batslib_err || batslib_err "$@"
   return 1
 }
@@ -119,7 +121,7 @@ batslib_print_kv_single_or_multi() {
   else
     local -i i
     for (( i=1; i < ${#pairs[@]}; i+=2 )); do
-      pairs[$i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
+      pairs[i]="$( batslib_prefix < <(printf '%s' "${pairs[$i]}") )"
     done
     batslib_print_kv_multi "${pairs[@]}"
   fi
@@ -136,6 +138,7 @@ batslib_prefix() {
 batslib_mark() {
   local -r symbol="$1"; shift
   # Sort line numbers.
+  # shellcheck disable=SC2046 # (warning): Quote this to prevent word splitting.
   set -- $( sort -nu <<< "$( printf '%d\n' "$@" )" )
 
   local line
@@ -366,6 +369,8 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
+    # glennj: I don't know what command's status `$?` is at this point
+    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \

--- a/exercises/practice/yacht/bats-extra.bash
+++ b/exercises/practice/yacht/bats-extra.bash
@@ -369,9 +369,9 @@ assert_output() {
       | fail
     fi
   elif (( is_mode_regexp )); then
-    # glennj: I don't know what command's status `$?` is at this point
-    # shellcheck disable=SC2319 # (warning): This $? refers to a condition, not a command. Assign to a variable to avoid it being overwritten.
+    # shellcheck disable=SC2319 # (warning) `$?` in a conditional expression: https://github.com/koalaman/shellcheck/wiki/SC2319
     if [[ '' =~ $expected ]] || (( $? == 2 )); then
+      # the regex matches an empty string or it is syntactically incorrect.
       echo "Invalid extended regular expression: \`$expected'" \
       | batslib_decorate 'ERROR: assert_output' \
       | fail


### PR DESCRIPTION
Ref: issue #783 

This PR will satisfy

```sh
find exercises/practice bin \
    \( -name '*.sh' -o -name '*.bash' \) \
    -not \( -name example.sh -o -path exercises/practice/markdown/markdown.sh \) \
    -print0 \
| xargs -0 shellcheck
```

I'd recommend reviewing by commit: the last commit is just copying one bats-extra.bash file to all the rest of the exercises.