### PR TITLE
[phone-number] Add a Jinja test template

### DIFF
--- a/exercises/practice/phone-number/.meta/template.j2
+++ b/exercises/practice/phone-number/.meta/template.j2
@@ -1,0 +1,15 @@
+{{ header }}
+{% for idx, case in cases %}
+@test "{{ case["description"] }}" {
+  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  run bash {{ solution }} "{{ case["input"]["phrase"] }}"
+{%- if case["expect_error"] %}
+  assert_failure
+  {#- The error message from the canonical data is not used. #}
+  assert_output "Invalid number.  [1]NXX-NXX-XXXX N=2-9, X=0-9"
+{%- else %}
+  assert_success
+  assert_output "{{ case["expected"] }}"
+{%- endif %}
+}
+{% endfor %}

--- a/exercises/practice/phone-number/phone_number.bats
+++ b/exercises/practice/phone-number/phone_number.bats
@@ -1,10 +1,11 @@
 #!/usr/bin/env bats
 load bats-extra
 
-# local version: 1.7.0.0
+# generated on 2026-06-28T22:42:36+00:00
+# local version: 2.0.0.0
 
 @test "cleans the number" {
-  #[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  # [[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash phone_number.sh "(223) 456-7890"
   assert_success
   assert_output "2234567890"


### PR DESCRIPTION
Note, the error message from the canonical data is not used.
