### PR TITLE
Remove the index from the test case loop; simplify the cases object

### DIFF
--- a/bin/generate_tests
+++ b/bin/generate_tests
@@ -119,7 +119,7 @@ def generate(specs: pathlib.Path, exercise: pathlib.Path) -> None:
         """
     ).strip()
     data = {
-        "cases": list(enumerate(cases)),
+        "cases": cases,
         "header": header,
         "solution": json.loads((exercise / ".meta/config.json").read_text())["files"]["solution"][0]
     }

--- a/exercises/practice/acronym/.meta/template.j2
+++ b/exercises/practice/acronym/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["phrase"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/affine-cipher/.meta/template.j2
+++ b/exercises/practice/affine-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["property"] }} {{ case["input"]["key"]["a"] }} {{ case["input"]["key"]["b"] }} "{{ case["input"]["phrase"] }}"
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/all-your-base/.meta/template.j2
+++ b/exercises/practice/all-your-base/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["inputBase"] }} "{{ case["input"]["digits"] | join(" ") }}" {{ case["input"]["outputBase"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/allergies/.meta/template.j2
+++ b/exercises/practice/allergies/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test {{ case["descriptions"] | join(":") | quote }} {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "allergicTo" %}
     run bash {{ solution }} {{ case["input"]["score"] }} allergic_to {{ case["input"]["item"] }}
 

--- a/exercises/practice/anagram/.meta/template.j2
+++ b/exercises/practice/anagram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["subject"] }}" "{{ case["input"]["candidates"] | join(" ") }}"
   assert_success
 {%- if case["expected"] | length == 0 %}

--- a/exercises/practice/armstrong-numbers/.meta/template.j2
+++ b/exercises/practice/armstrong-numbers/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["input"]["number"] }}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/atbash-cipher/.meta/template.j2
+++ b/exercises/practice/atbash-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["property"] }} "{{ case["input"]["phrase"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/binary-search/.meta/template.j2
+++ b/exercises/practice/binary-search/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["expect_error"] %}
     expected="-1"
 {%- else %}

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} ${{ case["input"]["heyBob"] | repr }}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/bottle-song/.meta/template.j2
+++ b/exercises/practice/bottle-song/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="\
 {{ case["expected"] | join("\n") }}"
     run bash {{ solution }} {{ case["input"]["startBottles"] }} {{ case["input"]["takeDown"] }}

--- a/exercises/practice/bowling/.meta/template.j2
+++ b/exercises/practice/bowling/.meta/template.j2
@@ -4,9 +4,9 @@
 # shell script. We'll just pass in all the individual rolls
 # and expect the score (or error) as output.
 
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- set args = [solution] + case["input"]["previousRolls"] %}
 {%- if case["property"] == "roll" %}{%- set args = args + [case["input"]["roll"]] %}{%- endif %}
     run bash {{ args | join(" ") }}

--- a/exercises/practice/change/.meta/template.j2
+++ b/exercises/practice/change/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["expect_error"] %}
     expected="{{ case["expect_error_msg"] }}"
 {%- else %}

--- a/exercises/practice/clock/.meta/template.j2
+++ b/exercises/practice/clock/.meta/template.j2
@@ -16,9 +16,9 @@
 #
 # The clock script will output the clock value in %H:%M format
 
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "create" %}
     run bash {{ solution }} {{ case["input"]["hour"] }} {{ case["input"]["minute"] }}
 {%- elif case["property"] == "add" %}

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["input"]["number"] }}
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/crypto-square/.meta/template.j2
+++ b/exercises/practice/crypto-square/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["plaintext"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/darts/.meta/template.j2
+++ b/exercises/practice/darts/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["x"] }} {{ case["input"]["y"] }}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/diamond/.meta/template.j2
+++ b/exercises/practice/diamond/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   expected="$(cat << EOT
 {{ case["expected"] | join("\n") }}
 EOT

--- a/exercises/practice/difference-of-squares/.meta/template.j2
+++ b/exercises/practice/difference-of-squares/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{
     case["property"] | camel_to_snake | replace("difference_of_squares", "difference")
   }} {{ case["input"]["number"] }}

--- a/exercises/practice/dnd-character/.meta/template.j2
+++ b/exercises/practice/dnd-character/.meta/template.j2
@@ -8,10 +8,10 @@
 
 
 # ability modifier
-{% for idx, case in cases %}
+{% for case in cases %}
 {%- if case["property"] == "modifier" %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["property"] }} {{ case["input"]["score"] }}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/dnd-character/dnd_character.bats
+++ b/exercises/practice/dnd-character/dnd_character.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 load bats-extra
 
-# generated on 2026-06-29T18:26:21+00:00
-# local version: 2.0.0.0
+# generated on 2026-08-13T17:30:08+00:00
 
 # usage: dnd_character.sh modifier n
 # -> output expected modifier

--- a/exercises/practice/eliuds-eggs/.meta/template.j2
+++ b/exercises/practice/eliuds-eggs/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["number"] }}
     assert_success
     assert_output {{ case["expected"] }}

--- a/exercises/practice/flower-field/.meta/template.j2
+++ b/exercises/practice/flower-field/.meta/template.j2
@@ -4,9 +4,9 @@ join() {
     local IFS=$'\n'
     echo "$*"
 }
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     input=({% for line in case["input"]["garden"] %}
         "{{ line }}"
         {%- endfor %}

--- a/exercises/practice/food-chain/.meta/template.j2
+++ b/exercises/practice/food-chain/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="{{ case["expected"] | join("\n") }}"
     run bash {{ solution }} {{ case["input"]["startVerse"] }} {{ case["input"]["endVerse"] }}
     assert_success

--- a/exercises/practice/forth/.meta/template.j2
+++ b/exercises/practice/forth/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} <<END
 {{ case["input"]["instructions"] | join("\n") }}
 END

--- a/exercises/practice/game-of-life/.meta/template.j2
+++ b/exercises/practice/game-of-life/.meta/template.j2
@@ -3,9 +3,9 @@ join() {
     local IFS=$'\n'
     echo "$*"
 }
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     input=(
 {%- for row in case["input"]["matrix"] %}
         "{{ row | join("") }}"

--- a/exercises/practice/gigasecond/.meta/template.j2
+++ b/exercises/practice/gigasecond/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} '{{ case["input"]["moment"] }}'
 
   assert_success

--- a/exercises/practice/grains/.meta/template.j2
+++ b/exercises/practice/grains/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "total" %}
   run bash {{ solution }} total
 {%- else %}

--- a/exercises/practice/hamming/.meta/template.j2
+++ b/exercises/practice/hamming/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} '{{ case["input"]["strand1"] }}' '{{ case["input"]["strand2"] }}'
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -1,5 +1,5 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
   run bash {{ solution }}
 

--- a/exercises/practice/house/.meta/template.j2
+++ b/exercises/practice/house/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<END
 {{ case["expected"] | join("\n") }}
 END

--- a/exercises/practice/intergalactic-transmission/.meta/template.j2
+++ b/exercises/practice/intergalactic-transmission/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["property"]  | camel_to_snake }} "{{ case["input"]["message"] | join(" ") }}"
     assert_success
 {%- if case["expect_error"] %}

--- a/exercises/practice/isbn-verifier/.meta/template.j2
+++ b/exercises/practice/isbn-verifier/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} '{{ case["input"]["isbn"] }}'
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/isogram/.meta/template.j2
+++ b/exercises/practice/isogram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} '{{ case["input"]["phrase"] }}'
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/kindergarten-garden/.meta/template.j2
+++ b/exercises/practice/kindergarten-garden/.meta/template.j2
@@ -2,9 +2,9 @@
 
 # Note: using ANSI-C Quoting here
 # see https://www.gnu.org/software/bash/manual/bash.html#ANSI_002dC-Quoting
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} ${{ case["input"]["diagram"] | repr }} "{{ case["input"]["student"] }}"
     assert_success
     assert_output "{{ case["expected"] | join(" ") }}"

--- a/exercises/practice/knapsack/.meta/template.j2
+++ b/exercises/practice/knapsack/.meta/template.j2
@@ -7,9 +7,9 @@
 # should return:
 #       90
 #
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["maximumWeight"] }} {%- for item in case["input"]["items"] %} {{ item["weight"] }}:{{ item["value"] }}{%- endfor %}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/largest-series-product/.meta/template.j2
+++ b/exercises/practice/largest-series-product/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["digits"] }}" "{{ case["input"]["span"] }}"
 {%- if case["expect_error"] %}
     expected="{{ case["expect_error_msg"] }}"

--- a/exercises/practice/leap/.meta/template.j2
+++ b/exercises/practice/leap/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["input"]["year"] }}
 
   assert_success

--- a/exercises/practice/line-up/.meta/template.j2
+++ b/exercises/practice/line-up/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["name"] }}" {{ case["input"]["number"] }}
 
     assert_success

--- a/exercises/practice/list-ops/.meta/template.j2
+++ b/exercises/practice/list-ops/.meta/template.j2
@@ -11,9 +11,9 @@ fi
 
 setup() { source list_ops.sh; }
 
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "append" %}
     local list1=({{ case["input"]["list1"] | join(" ") }})
     local list2=({{ case["input"]["list2"] | join(" ") }})

--- a/exercises/practice/luhn/.meta/template.j2
+++ b/exercises/practice/luhn/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["value"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/markdown/.meta/template.j2
+++ b/exercises/practice/markdown/.meta/template.j2
@@ -5,9 +5,9 @@
 setup()    { export MD_FILE; MD_FILE=$( mktemp ); }
 teardown() { rm -f "$MD_FILE"; }
 
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     cat <<END > "$MD_FILE"
 {{ case["input"]["markdown"] }}
 END

--- a/exercises/practice/matching-brackets/.meta/template.j2
+++ b/exercises/practice/matching-brackets/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["value"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/meetup/.meta/template.j2
+++ b/exercises/practice/meetup/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["year"] }} {{ case["input"]["month"] }} {{ case["input"]["week"] }} {{ case["input"]["dayofweek"] }}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/nth-prime/.meta/template.j2
+++ b/exercises/practice/nth-prime/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["number"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/nucleotide-count/.meta/template.j2
+++ b/exercises/practice/nucleotide-count/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["strand"] }}"
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/ocr-numbers/.meta/template.j2
+++ b/exercises/practice/ocr-numbers/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} << INPUT
 {{ case["input"]["rows"] | join("\n") }}
 INPUT

--- a/exercises/practice/palindrome-products/.meta/template.j2
+++ b/exercises/practice/palindrome-products/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["property"] }} {{ case["input"]["min"] }} {{ case["input"]["max"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/pangram/.meta/template.j2
+++ b/exercises/practice/pangram/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} '{{ case["input"]["sentence"] }}'
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/pascals-triangle/.meta/template.j2
+++ b/exercises/practice/pascals-triangle/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<END
 {%- for row in case["expected"] %}
 {{ row | join(" ") | indent((case["expected"] | length) - loop.index, first=True) }}

--- a/exercises/practice/perfect-numbers/.meta/template.j2
+++ b/exercises/practice/perfect-numbers/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["number"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/phone-number/.meta/template.j2
+++ b/exercises/practice/phone-number/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["phrase"] }}"
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/pig-latin/.meta/template.j2
+++ b/exercises/practice/pig-latin/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["phrase"] }}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/poker/.meta/template.j2
+++ b/exercises/practice/poker/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["hands"] | join('" "') }}"
     assert_success
     {%- for hand in case["expected"] %}

--- a/exercises/practice/prime-factors/.meta/template.j2
+++ b/exercises/practice/prime-factors/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="{{ case["expected"] | join(" ") }}"
     run bash {{ solution }} {{ case["input"]["value"] }}
     assert_success

--- a/exercises/practice/protein-translation/.meta/template.j2
+++ b/exercises/practice/protein-translation/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["strand"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/proverb/.meta/template.j2
+++ b/exercises/practice/proverb/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<END
 {%- if case["expected"] %}
 {{ case["expected"] | join("\n") }}

--- a/exercises/practice/pythagorean-triplet/.meta/template.j2
+++ b/exercises/practice/pythagorean-triplet/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["input"]["n"] > 10000 %}
 
     # This test is very time-consuming for a brute force solution.

--- a/exercises/practice/rail-fence-cipher/.meta/template.j2
+++ b/exercises/practice/rail-fence-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "encode" %}
     run bash {{ solution }} -e {{ case["input"]["rails"] }} "{{ case["input"]["msg"] }}"
 {%- else %}

--- a/exercises/practice/raindrops/.meta/template.j2
+++ b/exercises/practice/raindrops/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["input"]["number"] }}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/rational-numbers/.meta/template.j2
+++ b/exercises/practice/rational-numbers/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] in ["add", "sub", "mul", "div"] %}
     {%- set op = {"add": "+", "sub": "-", "mul": "*", "div": "/"}[case["property"]] %}
     {%- set args = [op, case["input"]["r1"] | join("/"), case["input"]["r2"] | join("/")] %}

--- a/exercises/practice/rectangles/.meta/template.j2
+++ b/exercises/practice/rectangles/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["description"] == "no rows" %}
     run bash {{ solution }}
 {%- elif case["description"] == "no columns" %}

--- a/exercises/practice/resistor-color-duo/.meta/template.j2
+++ b/exercises/practice/resistor-color-duo/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["colors"] | join(" ") }}
 {%- if case["expect_error"] %}
     {#- The error message from the canonical data is not used. #}

--- a/exercises/practice/resistor-color-trio/.meta/template.j2
+++ b/exercises/practice/resistor-color-trio/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["colors"] | join('" "') }}"
     assert_success
     assert_output "{{ case["expected"]["value"] }} {{ case["expected"]["unit"] }}"

--- a/exercises/practice/resistor-color/.meta/template.j2
+++ b/exercises/practice/resistor-color/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(" -> ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["property"] == "colorCode" %}
     run bash {{ solution }} code {{ case["input"]["color"] }}
     assert_success

--- a/exercises/practice/reverse-string/.meta/template.j2
+++ b/exercises/practice/reverse-string/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["value"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/rna-transcription/.meta/template.j2
+++ b/exercises/practice/rna-transcription/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["dna"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/roman-numerals/.meta/template.j2
+++ b/exercises/practice/roman-numerals/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["input"]["number"] }}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/rotational-cipher/.meta/template.j2
+++ b/exercises/practice/rotational-cipher/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="{{ case["expected"] }}"
     run bash {{ solution }} "{{ case["input"]["text"] }}" {{ case["input"]["shiftKey"] }}
     assert_success

--- a/exercises/practice/run-length-encoding/.meta/template.j2
+++ b/exercises/practice/run-length-encoding/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="{{ case["expected"] }}"
 {%- if case["property"] == "consistency" %}
     run bash run_length_encoding.sh encode "{{ case["input"]["string"] }}"

--- a/exercises/practice/satellite/.meta/template.j2
+++ b/exercises/practice/satellite/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["preorder"] | join(" ") }}" "{{ case["input"]["inorder"] | join(" ") }}"
 {%- if case["expect_error"] %}
   assert_failure

--- a/exercises/practice/say/.meta/template.j2
+++ b/exercises/practice/say/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["number"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/scrabble-score/.meta/template.j2
+++ b/exercises/practice/scrabble-score/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test '{{ case["description"] }}' {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} '{{ case["input"]["word"] }}'
 
   assert_success

--- a/exercises/practice/secret-handshake/.meta/template.j2
+++ b/exercises/practice/secret-handshake/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["number"] }}
     assert_success
     assert_output "{{ case["expected"] | join(",") }}"

--- a/exercises/practice/series/.meta/template.j2
+++ b/exercises/practice/series/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["expect_error"] %}
     expected="{{ case["expect_error_msg"] }}"
     run bash {{ solution }} "{{ case["input"]["series"] }}" {{ case["input"]["sliceLength"] }}

--- a/exercises/practice/sieve/.meta/template.j2
+++ b/exercises/practice/sieve/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected="{{ case["expected"] | join(" ") }}"
     run bash {{ solution }} {{ case["input"]["limit"] }}
     assert_success

--- a/exercises/practice/space-age/.meta/template.j2
+++ b/exercises/practice/space-age/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["planet"] }}" {{ case["input"]["seconds"] }}
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/spiral-matrix/.meta/template.j2
+++ b/exercises/practice/spiral-matrix/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["size"] }}
     expected="{{ case["expected"] | map("join", " ") | join("\n") }}"
     assert_success

--- a/exercises/practice/square-root/.meta/template.j2
+++ b/exercises/practice/square-root/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["radicand"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/sublist/.meta/template.j2
+++ b/exercises/practice/sublist/.meta/template.j2
@@ -2,9 +2,9 @@
 
 # Lists are ordered and sequential: do not sort or reorder them.
 # Lists are given in JSON format.
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["listOne"] }}" "{{ case["input"]["listTwo"] }}"
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/sum-of-multiples/.meta/template.j2
+++ b/exercises/practice/sum-of-multiples/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} {{ case["input"]["limit"] }} {{ case["input"]["factors"] | join(" ") }}
     assert_success
     assert_output "{{ case["expected"] }}"

--- a/exercises/practice/swift-scheduling/.meta/template.j2
+++ b/exercises/practice/swift-scheduling/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["description"] }}" "{{ case["input"]["meetingStart"] }}"
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/tournament/.meta/template.j2
+++ b/exercises/practice/tournament/.meta/template.j2
@@ -11,9 +11,9 @@ setup() {
     [[ -t 0 ]] && HAS_TTY=1 || HAS_TTY=0
 }
 teardown() { rm -f "$INPUT_FILE"; }
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
     input=$( cat <<INPUT
 {%- if case["input"]["rows"] %}

--- a/exercises/practice/transpose/.meta/template.j2
+++ b/exercises/practice/transpose/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     input=$(cat <<END
 {{ case["input"]["lines"] | join("\n") }}
 END

--- a/exercises/practice/triangle/.meta/template.j2
+++ b/exercises/practice/triangle/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["descriptions"] | join(": ") }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} {{ case["property"] }} {{ case["input"]["sides"] | join(" ") }}
   assert_success
   assert_output "{{ case["expected"] }}"

--- a/exercises/practice/twelve-days/.meta/template.j2
+++ b/exercises/practice/twelve-days/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     expected=$(cat <<END
 {{ case["expected"] | join("\n") }}
 END

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
 {%- if case["expect_error"] %}
     run bash {{ solution }} {{ case["input"]["bucketOne"] }} {{ case["input"]["bucketTwo"] }} {{ case["input"]["goal"] }} "{{ case["input"]["startBucket"] }}"
     assert_failure

--- a/exercises/practice/two-fer/.meta/template.j2
+++ b/exercises/practice/two-fer/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-{%- if idx == 0 %}
+{%- if loop.first %}
   # [[ $BATS_RUN_SKIPPED == "true" ]] || skip
 
   # The above line controls whether to skip the test.

--- a/exercises/practice/variable-length-quantity/.meta/template.j2
+++ b/exercises/practice/variable-length-quantity/.meta/template.j2
@@ -4,9 +4,9 @@
 # *** Input and Output numbers are expressed in hexadecimal.
 #
 
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     {%- set hex_input = [] %}
     {%- for num in case["input"]["integers"] %}
         {%- set _ = hex_input.append('%02X' % num) %}

--- a/exercises/practice/word-count/.meta/template.j2
+++ b/exercises/practice/word-count/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
   run bash {{ solution }} "{{ case["input"]["sentence"] }}"
   assert_success
 {%- for word, count in case["expected"].items() %}

--- a/exercises/practice/wordy/.meta/template.j2
+++ b/exercises/practice/wordy/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["question"] }}"
 {%- if case["expect_error"] %}
     assert_failure

--- a/exercises/practice/yacht/.meta/template.j2
+++ b/exercises/practice/yacht/.meta/template.j2
@@ -1,7 +1,7 @@
 {{ header }}
-{% for idx, case in cases %}
+{% for case in cases %}
 @test "{{ case["description"] }}" {
-    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
+    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     run bash {{ solution }} "{{ case["input"]["category"] }}" {{ case["input"]["dice"] | join(" ") }}
     assert_success
     assert_output "{{ case["expected"] }}"


### PR DESCRIPTION
Summarized changes:

```
» g diff | grep '^[+-][^+-]' | sort | uniq -c
      1 +        "cases": cases,
      1 -        "cases": list(enumerate(cases)),
     90 +{% for case in cases %}
     90 -{% for idx, case in cases %}
      1 -{%- if idx == 0 %}
     60 -    {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     28 -  {% if idx == 0 %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
      1 +{%- if loop.first %}
     60 +    {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
     28 +  {% if loop.first %}# {% endif %}[[ $BATS_RUN_SKIPPED == "true" ]] || skip
```
